### PR TITLE
feat: add response dtos

### DIFF
--- a/apps/backend-relayer/src/modules/ads/ad.controller.ts
+++ b/apps/backend-relayer/src/modules/ads/ad.controller.ts
@@ -21,6 +21,14 @@ import {
   WithdrawalAdDto,
   ConfirmAdActionDto,
   CloseAdDto,
+  ListAdResponseDto,
+  AdResponseDto,
+  CreateAdResponseDto,
+  FundAdResponseDto,
+  WithdrawAdResponseDto,
+  ConfirmChainActionResponseDto,
+  AdUpdateResponseDto,
+  CloseAdResponseDto,
 } from '../ads/dto/ad.dto';
 import type { Request } from 'express';
 import { UserJwtGuard } from '../../common/guards/user-jwt.guard';
@@ -31,20 +39,24 @@ export class AdsController {
   constructor(private readonly ads: AdsService) {}
   @Get()
   @HttpCode(HttpStatus.OK)
-  list(@Query() query: QueryAdsDto) {
+  list(@Query() query: QueryAdsDto): Promise<ListAdResponseDto> {
     return this.ads.list(query);
   }
 
   @Get(':id')
   @HttpCode(HttpStatus.OK)
-  get(@Param('id', new ParseUUIDPipe()) id: string) {
+  get(@Param('id', new ParseUUIDPipe()) id: string): Promise<AdResponseDto> {
     return this.ads.getById(id);
   }
+
   @ApiBearerAuth()
   @Post('create')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.CREATED)
-  create(@Req() req: Request, @Body() dto: CreateAdDto) {
+  create(
+    @Req() req: Request,
+    @Body() dto: CreateAdDto,
+  ): Promise<CreateAdResponseDto> {
     return this.ads.create(req, dto);
   }
 
@@ -56,7 +68,7 @@ export class AdsController {
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: FundAdDto,
-  ) {
+  ): Promise<FundAdResponseDto> {
     return this.ads.fund(req, id, dto);
   }
 
@@ -68,7 +80,7 @@ export class AdsController {
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: WithdrawalAdDto,
-  ) {
+  ): Promise<WithdrawAdResponseDto> {
     return this.ads.withdraw(req, id, dto);
   }
 
@@ -80,31 +92,31 @@ export class AdsController {
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: ConfirmAdActionDto,
-  ) {
+  ): Promise<ConfirmChainActionResponseDto> {
     return this.ads.confirmChainAction(req, id, dto);
   }
 
   @ApiBearerAuth()
-  @Patch(':id')
+  @Patch(':id/update')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.OK)
   update(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: UpdateAdDto,
-  ) {
+  ): Promise<AdUpdateResponseDto> {
     return this.ads.update(req, id, dto);
   }
 
   @ApiBearerAuth()
-  @Post(':id')
+  @Post(':id/close')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.OK)
   async close(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: CloseAdDto,
-  ) {
-    await this.ads.close(req, id, dto);
+  ): Promise<CloseAdResponseDto> {
+    return this.ads.close(req, id, dto);
   }
 }

--- a/apps/backend-relayer/src/modules/ads/ad.service.ts
+++ b/apps/backend-relayer/src/modules/ads/ad.service.ts
@@ -276,7 +276,7 @@ export class AdsService {
         data: {
           adId: ad.id,
           signature: reqContractDetails.signature,
-          reqHash: reqContractDetails.msgHash,
+          reqHash: reqContractDetails.reqHash,
           log: {
             create: [
               {
@@ -355,7 +355,7 @@ export class AdsService {
         data: {
           adId: ad.id,
           signature: reqContractDetails.signature,
-          reqHash: reqContractDetails.msgHash,
+          reqHash: reqContractDetails.reqHash,
           log: {
             create: [
               {
@@ -460,7 +460,7 @@ export class AdsService {
         data: {
           adId: ad.id,
           signature: reqContractDetails.signature,
-          reqHash: reqContractDetails.msgHash,
+          reqHash: reqContractDetails.reqHash,
           log: {
             create: [
               {
@@ -590,7 +590,7 @@ export class AdsService {
       throw new BadRequestException('Ad has active locks and cannot be closed');
 
     if (ad.status === 'CLOSED') {
-      return;
+      throw new BadRequestException('Ad is already closed');
     }
 
     const reqContractDetails =
@@ -607,7 +607,7 @@ export class AdsService {
         data: {
           adId: ad.id,
           signature: reqContractDetails.signature,
-          reqHash: reqContractDetails.msgHash,
+          reqHash: reqContractDetails.reqHash,
           log: {
             create: [
               {
@@ -689,7 +689,7 @@ export class AdsService {
       chainId: ad.route.fromToken.chain.chainId,
       contractAddress: ad.route.fromToken.chain
         .adManagerAddress as `0x${string}`,
-      msgHash: adLogUpdate.reqHash as `0x${string}`,
+      reqHash: adLogUpdate.reqHash as `0x${string}`,
     });
 
     if (!isValidated)

--- a/apps/backend-relayer/src/modules/ads/dto/ad.dto.ts
+++ b/apps/backend-relayer/src/modules/ads/dto/ad.dto.ts
@@ -1,6 +1,7 @@
 import { IsIn, IsOptional, IsString, IsUUID, Matches } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { JsonObject, JsonArray } from '@prisma/client/runtime/library';
 
 export class QueryAdsDto {
   @ApiPropertyOptional({
@@ -166,4 +167,325 @@ export class ConfirmAdActionDto {
   @IsOptional()
   @IsString()
   signature?: string;
+}
+
+export class AdResponseDto {
+  @ApiProperty({
+    type: String,
+    format: 'uuid',
+    description: 'Unique identifier of the ad entry',
+  })
+  id!: string;
+
+  @ApiProperty({ description: 'EVM address of the ad creator' })
+  creatorAddress!: string;
+
+  @ApiProperty({
+    type: String,
+    format: 'uuid',
+    description: 'Associated route identifier',
+  })
+  routeId!: string;
+
+  @ApiProperty({ description: 'Token ID for the source/input token' })
+  fromTokenId!: string;
+
+  @ApiProperty({ description: 'Token ID for the target/output token' })
+  toTokenId!: string;
+
+  @ApiProperty({
+    pattern: '^d+$',
+    description: 'Total amount allocated to the pool (in smallest token units)',
+  })
+  poolAmount!: string;
+
+  @ApiProperty({
+    pattern: '^d+$',
+    description:
+      'Current available amount in the pool (in smallest token units)',
+  })
+  availableAmount!: string;
+
+  @ApiProperty({
+    pattern: '^d+$',
+    nullable: true,
+    description: 'Minimum transaction amount allowed (in smallest token units)',
+  })
+  minAmount!: string | null;
+
+  @ApiProperty({
+    pattern: '^d+$',
+    nullable: true,
+    description: 'Maximum transaction amount allowed (in smallest token units)',
+  })
+  maxAmount!: string | null;
+
+  @ApiProperty({
+    enum: ['ACTIVE', 'PAUSED', 'EXHAUSTED', 'CLOSED'],
+    description: 'Current status of the advertisement',
+  })
+  status!: string;
+
+  @ApiProperty({
+    nullable: true,
+    description: 'Additional custom metadata associated with the ad',
+  })
+  metadata!: string | number | boolean | JsonObject | JsonArray | null;
+
+  @ApiProperty({ description: 'Timestamp when the ad entry was created' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Timestamp of the last update to the ad entry' })
+  updatedAt!: string;
+}
+
+export class ListAdResponseDto {
+  @ApiProperty({ type: [AdResponseDto] })
+  data!: AdResponseDto[];
+
+  @ApiProperty({ type: String, nullable: true })
+  nextCursor: string | null;
+}
+
+export class CreateAdResponseDto {
+  @ApiProperty({
+    description: 'Contract address for the advertisement',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  contractAddress!: string;
+
+  @ApiProperty({
+    description: 'Signature for the transaction request',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  signature!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request auth token',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  authToken!: string;
+
+  @ApiProperty({
+    description: 'Time until the request expires',
+    example: 3600,
+  })
+  timeToExpire!: number;
+
+  @ApiProperty({
+    description: 'Unique identifier for the advertisement',
+    example: 'ad123',
+  })
+  adId!: string;
+
+  @ApiProperty({
+    description: 'Token address for the advertisement',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  adToken!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Chain ID for the order',
+    example: '1',
+  })
+  orderChainId!: string;
+
+  @ApiProperty({
+    description: 'Recipient address for the advertisement',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  adRecipient!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request hash',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  reqHash!: `0x${string}`;
+}
+export class FundAdResponseDto {
+  @ApiProperty({
+    description: 'Contract address for the advertisement',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  contractAddress!: string;
+
+  @ApiProperty({
+    description: 'Signature for the transaction request',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  signature!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request auth token',
+    example: '0xd35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  authToken!: string;
+
+  @ApiProperty({
+    description: 'Time until the request expires',
+    example: 3600,
+  })
+  timeToExpire!: number;
+
+  @ApiProperty({
+    description: 'Unique identifier for the advertisement',
+    example: 'ad123',
+  })
+  adId!: string;
+
+  @ApiProperty({
+    description: 'Amount to fund',
+    example: '1000000000000000000',
+  })
+  amount!: string;
+
+  @ApiProperty({
+    description: 'Request hash',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  reqHash!: `0x${string}`;
+}
+
+export class WithdrawAdResponseDto {
+  @ApiProperty({
+    description: 'Contract address for the advertisement',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  contractAddress!: string;
+
+  @ApiProperty({
+    description: 'Signature for the transaction request',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  signature!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request auth token',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  authToken!: string;
+
+  @ApiProperty({
+    description: 'Time until the request expires',
+    example: 3600,
+  })
+  timeToExpire!: number;
+
+  @ApiProperty({
+    description: 'Unique identifier for the advertisement',
+    example: 'ad123',
+  })
+  adId!: string;
+
+  @ApiProperty({
+    description: 'Amount to withdraw',
+    example: '1000000000000000000',
+  })
+  amount!: string;
+
+  @ApiProperty({
+    description: 'Destination address for withdrawal',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  to!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request hash',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  reqHash!: `0x${string}`;
+}
+
+export class ConfirmChainActionResponseDto {
+  @ApiProperty({
+    description: 'Whether the chain action was confirmed successfully',
+    example: true,
+  })
+  success!: boolean;
+}
+
+export class AdUpdateResponseDto {
+  @ApiProperty({
+    type: String,
+    format: 'uuid',
+    description: 'Unique identifier of the ad entry',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'EVM address of the ad creator',
+  })
+  creatorAddress!: string;
+
+  @ApiProperty({
+    pattern: '^d+$',
+    nullable: true,
+    description: 'Minimum transaction amount allowed (in smallest token units)',
+  })
+  minAmount!: string | null;
+
+  @ApiProperty({
+    pattern: '^d+$',
+    nullable: true,
+    description: 'Maximum transaction amount allowed (in smallest token units)',
+  })
+  maxAmount!: string | null;
+
+  @ApiProperty({
+    nullable: true,
+    description: 'Additional custom metadata associated with the ad',
+  })
+  metadata!: string | number | boolean | JsonObject | JsonArray | null;
+}
+
+export class CloseAdResponseDto {
+  @ApiProperty({
+    description: 'Contract address for the advertisement',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  contractAddress!: string;
+
+  @ApiProperty({
+    description: 'Signature for the transaction request',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  signature!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request auth token',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  authToken!: string;
+
+  @ApiProperty({
+    description: 'Time until the request expires',
+    example: 3600,
+  })
+  timeToExpire!: number;
+
+  @ApiProperty({
+    description: 'Unique identifier for the advertisement',
+    example: 'ad123',
+  })
+  adId!: string;
+
+  @ApiProperty({
+    description: 'Destination address for withdrawal',
+    example: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+  })
+  to!: `0x${string}`;
+
+  @ApiProperty({
+    description: 'Request hash',
+    example:
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  })
+  reqHash!: `0x${string}`;
 }

--- a/apps/backend-relayer/src/modules/chains/chain.controller.ts
+++ b/apps/backend-relayer/src/modules/chains/chain.controller.ts
@@ -7,7 +7,11 @@ import {
   Query,
 } from '@nestjs/common';
 import { ChainService } from './chain.service';
-import { QueryChainsDto } from './dto/chain.dto';
+import {
+  ChainResponseDto,
+  ListChainsResponseDto,
+  QueryChainsDto,
+} from './dto/chain.dto';
 import { ParseChainIdPipe } from '../../common/pipes/parse-chain-id.pipe';
 import { ApiTags } from '@nestjs/swagger';
 
@@ -19,14 +23,16 @@ export class ChainController {
   // GET /v1/chains?name=&chainId=&limit=&cursor=
   @Get()
   @HttpCode(HttpStatus.OK)
-  listChains(@Query() query: QueryChainsDto) {
+  listChains(@Query() query: QueryChainsDto): Promise<ListChainsResponseDto> {
     return this.chains.listChainsPublic(query);
   }
 
   // GET /v1/chains/:chainId
   @Get(':chainId')
   @HttpCode(HttpStatus.OK)
-  getChain(@Param('chainId', ParseChainIdPipe) chainId: string) {
+  getChain(
+    @Param('chainId', ParseChainIdPipe) chainId: string,
+  ): Promise<ChainResponseDto> {
     return this.chains.getByChainId(chainId);
   }
 }

--- a/apps/backend-relayer/src/modules/chains/dto/chain.dto.ts
+++ b/apps/backend-relayer/src/modules/chains/dto/chain.dto.ts
@@ -116,3 +116,47 @@ export class UpdateChainDto {
   @IsString()
   orderPortalAddress?: string;
 }
+
+export class ChainResponseDto {
+  @ApiProperty({ description: 'Chain name', example: 'Ethereum Mainnet' })
+  name!: string;
+
+  @ApiProperty({ description: 'Chain ID', example: '1' })
+  chainId!: string;
+
+  @ApiProperty({
+    description: 'Ad Manager contract address',
+    example: '0x1234567890abcdef1234567890abcdef12345678',
+  })
+  adManagerAddress!: string;
+
+  @ApiProperty({
+    description: 'Order Portal contract address',
+    example: '0xabcdef1234567890abcdef1234567890abcdef12',
+  })
+  orderPortalAddress!: string;
+
+  @ApiProperty({
+    description: 'Creation timestamp',
+    example: '2023-01-01T00:00:00Z',
+  })
+  createdAt!: string;
+
+  @ApiProperty({
+    description: 'Last update timestamp',
+    example: '2023-01-01T00:00:00Z',
+  })
+  updatedAt!: string;
+}
+
+export class ListChainsResponseDto {
+  @ApiProperty({ type: [ChainResponseDto] })
+  rows!: ChainResponseDto[];
+
+  @ApiProperty({
+    description: 'Next pagination cursor',
+    example: 'xyz123',
+    nullable: true,
+  })
+  nextCursor!: string | null;
+}

--- a/apps/backend-relayer/src/modules/routes/dto/route.dto.ts
+++ b/apps/backend-relayer/src/modules/routes/dto/route.dto.ts
@@ -104,3 +104,75 @@ export class CreateRouteDto {
   @IsOptional()
   metadata?: object;
 }
+
+export class ChainDto {
+  @ApiProperty({ description: 'Chain ID', example: '1' })
+  id!: string;
+
+  @ApiProperty({ description: 'Chain name', example: 'Ethereum' })
+  name!: string;
+
+  @ApiProperty({ description: 'Chain ID string', example: '1' })
+  chainId!: string;
+}
+
+export class TokenDto {
+  @ApiProperty({
+    description: 'Token ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id!: string;
+
+  @ApiProperty({ description: 'Token symbol', example: 'ETH' })
+  symbol!: string;
+
+  @ApiProperty({ description: 'Token name', example: 'Ethereum' })
+  name!: string;
+
+  @ApiProperty({ description: 'Token contract address', example: '0x...' })
+  address!: string;
+
+  @ApiProperty({ description: 'Token decimals', example: 18 })
+  decimals!: number;
+
+  @ApiProperty({ description: 'Token kind', example: 'native' })
+  kind!: string;
+
+  @ApiProperty({ description: 'Token chain information' })
+  chain!: ChainDto;
+}
+
+export class RouteDataResponseDto {
+  @ApiProperty({ description: 'Route ID' })
+  id!: string;
+
+  @ApiProperty({ description: 'Route metadata' })
+  metadata!: object;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt!: string;
+
+  @ApiProperty({ description: 'Source token information' })
+  fromToken!: TokenDto;
+
+  @ApiProperty({ description: 'Destination token information' })
+  toToken!: TokenDto;
+}
+
+export class ListRouteResponseDto {
+  @ApiProperty({
+    description: 'Array of route data',
+    type: [RouteDataResponseDto],
+  })
+  data!: RouteDataResponseDto[];
+
+  @ApiProperty({
+    description: 'Next page cursor',
+    type: 'string',
+    nullable: true,
+  })
+  nextCursor!: string | null;
+}

--- a/apps/backend-relayer/src/modules/routes/route.controller.ts
+++ b/apps/backend-relayer/src/modules/routes/route.controller.ts
@@ -8,7 +8,11 @@ import {
   Query,
 } from '@nestjs/common';
 import { RoutesService } from './route.service';
-import { QueryRoutesDto } from './dto/route.dto';
+import {
+  ListRouteResponseDto,
+  QueryRoutesDto,
+  RouteDataResponseDto,
+} from './dto/route.dto';
 import { ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Routes')
@@ -19,14 +23,16 @@ export class RoutesController {
   // GET /v1/routes?fromTokenId&toTokenId&fromChainId&toChainId&symbol&limit&cursor
   @Get()
   @HttpCode(HttpStatus.OK)
-  list(@Query() query: QueryRoutesDto) {
+  list(@Query() query: QueryRoutesDto): Promise<ListRouteResponseDto> {
     return this.routes.list(query);
   }
 
   // GET /v1/routes/:id
   @Get(':id')
   @HttpCode(HttpStatus.OK)
-  get(@Param('id', new ParseUUIDPipe()) id: string) {
+  get(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<RouteDataResponseDto> {
     return this.routes.getById(id);
   }
 }

--- a/apps/backend-relayer/src/modules/token/dto/token.dto.ts
+++ b/apps/backend-relayer/src/modules/token/dto/token.dto.ts
@@ -189,3 +189,94 @@ export class UpdateTokenDto {
   })
   kind?: TokenKind;
 }
+
+export class TokenChainDto {
+  @ApiProperty({
+    description: 'Chain ID',
+    type: 'string',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Chain name',
+    type: 'string',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: 'EVM chain ID',
+    type: 'string',
+  })
+  chainId!: string;
+}
+
+export class TokenDataResponseDto {
+  @ApiProperty({
+    description: 'Token ID',
+    type: 'string',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Token symbol',
+    type: 'string',
+  })
+  symbol!: string;
+
+  @ApiProperty({
+    description: 'Token name',
+    type: 'string',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: 'Token address',
+    type: 'string',
+  })
+  address!: string;
+
+  @ApiProperty({
+    description: 'Token decimals',
+    type: 'number',
+  })
+  decimals!: number;
+
+  @ApiProperty({
+    description: 'Token kind',
+    type: 'string',
+  })
+  kind!: string;
+
+  @ApiProperty({
+    description: 'Creation timestamp',
+    type: 'string',
+  })
+  createdAt!: string;
+
+  @ApiProperty({
+    description: 'Last update timestamp',
+    type: 'string',
+  })
+  updatedAt!: string;
+
+  @ApiProperty({
+    description: 'Chain information',
+    type: TokenChainDto,
+  })
+  chain!: TokenChainDto;
+}
+
+export class ListTokenResponseDto {
+  @ApiProperty({
+    description: 'Array of token data',
+    type: [TokenDataResponseDto],
+  })
+  data!: TokenDataResponseDto[];
+
+  @ApiProperty({
+    description: 'Cursor for the next page of results',
+    type: 'string',
+    nullable: true,
+  })
+  nextCursor!: string | null;
+}

--- a/apps/backend-relayer/src/modules/token/token.controller.ts
+++ b/apps/backend-relayer/src/modules/token/token.controller.ts
@@ -9,7 +9,11 @@ import {
   ParseUUIDPipe,
 } from '@nestjs/common';
 import { TokenService } from './token.service';
-import { QueryTokensDto } from './dto/token.dto';
+import {
+  ListTokenResponseDto,
+  QueryTokensDto,
+  TokenDataResponseDto,
+} from './dto/token.dto';
 import { ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Tokens')
@@ -20,14 +24,16 @@ export class TokenController {
   // GET /v1/tokens?chainId=<number>&symbol&address&limit&cursor
   @Get()
   @HttpCode(HttpStatus.OK)
-  list(@Query() query: QueryTokensDto) {
+  list(@Query() query: QueryTokensDto): Promise<ListTokenResponseDto> {
     return this.tokens.list(query);
   }
 
   // GET /v1/tokens/:id (token UUID)
   @Get(':id')
   @HttpCode(HttpStatus.OK)
-  get(@Param('id', new ParseUUIDPipe()) id: string) {
+  get(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<TokenDataResponseDto> {
     return this.tokens.getById(id);
   }
 }

--- a/apps/backend-relayer/src/modules/trades/dto/trade.dto.ts
+++ b/apps/backend-relayer/src/modules/trades/dto/trade.dto.ts
@@ -126,7 +126,7 @@ export class CreateTradeDto {
   bridgerDstAddress!: string;
 }
 
-export class AuthorizeTradeDto {
+export class UnlockTradeDto {
   @ApiProperty({
     example: '0x1234567890...',
     description: 'Signature for trade authorization',
@@ -150,4 +150,270 @@ export class ConfirmTradeActionDto {
   @IsOptional()
   @IsString()
   signature?: string;
+}
+
+export class ChainDto {
+  @ApiProperty({ example: 'Ethereum' })
+  name!: string;
+}
+
+export class TokenDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id!: string;
+
+  @ApiProperty({ example: 'ETH' })
+  symbol!: string;
+
+  @ApiProperty()
+  chain!: ChainDto;
+}
+
+export class RouteDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id!: string;
+
+  @ApiProperty()
+  fromToken!: TokenDto;
+
+  @ApiProperty()
+  toToken!: TokenDto;
+}
+
+export class AdDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id!: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  routeId!: string;
+
+  @ApiProperty({ example: '0x1234567890abcdef' })
+  creatorAddress!: string;
+}
+
+export class TradeResponseDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id!: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  routeId!: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  adId!: string;
+
+  @ApiProperty({ example: '0x1234567890abcdef' })
+  adCreatorAddress!: string;
+
+  @ApiProperty({ example: '0x1234567890abcdef' })
+  bridgerAddress!: string;
+
+  @ApiProperty({ example: '1000' })
+  amount!: string;
+
+  @ApiProperty({ example: 'PENDING' })
+  status!: string;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+
+  @ApiProperty()
+  ad!: AdDto;
+
+  @ApiProperty()
+  route!: RouteDto;
+}
+
+export class ListTradesResponseDto {
+  @ApiProperty({ type: [TradeResponseDto] })
+  data!: TradeResponseDto[];
+
+  @ApiProperty({ example: 'nextPageToken', nullable: true })
+  nextCursor!: string | null;
+}
+
+export class LockForOrderResponseDto {
+  @ApiProperty({
+    example: '0x1234567890abcdef',
+    description: 'Contract address',
+  })
+  @IsString()
+  contractAddress!: string;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Signature value',
+  })
+  @IsString()
+  signature!: string;
+
+  @ApiProperty({
+    example: 'token123',
+    description: 'Authentication token',
+  })
+  @IsString()
+  authToken!: string;
+
+  @ApiProperty({
+    example: 3600,
+    description: 'Time until request expires in seconds',
+  })
+  @IsInt()
+  timeToExpire!: number;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Request hash',
+  })
+  @IsString()
+  reqHash!: string;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Order hash',
+  })
+  @IsString()
+  orderHash!: string;
+}
+
+export class CreateOrderRequestContractDetailsDto {
+  @ApiProperty({
+    example: '0x1234567890abcdef',
+    description: 'Contract address',
+  })
+  @IsString()
+  contractAddress!: string;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Signature value',
+  })
+  @IsString()
+  signature!: `0x${string}`;
+
+  @ApiProperty({
+    example: 'token123',
+    description: 'Authentication token',
+  })
+  @IsString()
+  authToken!: string;
+
+  @ApiProperty({
+    example: 3600,
+    description: 'Time until expiration in seconds',
+  })
+  @IsInt()
+  timeToExpire!: number;
+
+  @ApiProperty({
+    description: 'Order portal parameters',
+  })
+  orderParams!: any;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Order hash',
+  })
+  @IsString()
+  orderHash!: `0x${string}`;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Request hash',
+  })
+  @IsString()
+  reqHash!: `0x${string}`;
+}
+
+export class CreateTradeRequestContractResponseDto {
+  @ApiProperty({
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'Trade ID',
+  })
+  @IsUUID()
+  tradeId!: string;
+
+  @ApiProperty({
+    description: 'Contract request details',
+  })
+  reqContractDetails!: CreateOrderRequestContractDetailsDto;
+}
+
+export class UnlockOrderResponseDto {
+  @ApiProperty({
+    example: '0x1234567890abcdef',
+    description: 'Contract address',
+  })
+  @IsString()
+  contractAddress!: `0x${string}`;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Signature value',
+  })
+  @IsString()
+  signature!: `0x${string}`;
+
+  @ApiProperty({
+    example: 'token123',
+    description: 'Authentication token',
+  })
+  @IsString()
+  authToken!: string;
+
+  @ApiProperty({
+    example: 3600,
+    description: 'Time until expiration in seconds',
+  })
+  @IsInt()
+  timeToExpire!: number;
+
+  @ApiProperty({
+    description: 'Order parameters',
+  })
+  orderParams!: any;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Nullifier hash',
+  })
+  @IsString()
+  nullifierHash!: string;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Target root',
+  })
+  @IsString()
+  targetRoot!: string;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Proof value',
+  })
+  @IsString()
+  proof!: string;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Order hash',
+  })
+  @IsString()
+  orderHash!: `0x${string}`;
+
+  @ApiProperty({
+    example: '0x1234567890abcdef...',
+    description: 'Request hash',
+  })
+  @IsString()
+  reqHash!: `0x${string}`;
+}
+
+export class ConfirmChainActionResponseDto {
+  @ApiProperty({
+    description: 'Whether the chain action was confirmed successfully',
+    example: true,
+  })
+  success!: boolean;
 }

--- a/apps/backend-relayer/src/modules/trades/trade.controller.spec.ts
+++ b/apps/backend-relayer/src/modules/trades/trade.controller.spec.ts
@@ -18,7 +18,7 @@ describe('TradesController (unit)', () => {
             list: jest.fn(),
             getById: jest.fn(),
             create: jest.fn(),
-            authorize: jest.fn(),
+            unlock: jest.fn(),
           },
         },
         PrismaService,
@@ -77,10 +77,10 @@ describe('TradesController (unit)', () => {
     const req: any = { user: { sub: '0xB' } };
 
     const spy = jest
-      .spyOn(service, 'authorize')
+      .spyOn(service, 'unlock')
       .mockResolvedValueOnce({ status: 'PROOF_READY' } as any);
 
-    const res = await controller.authorize(req, 'tr-1', {
+    const res = await controller.unlock(req, 'tr-1', {
       signature: '0x01',
     });
 

--- a/apps/backend-relayer/src/modules/trades/trade.controller.ts
+++ b/apps/backend-relayer/src/modules/trades/trade.controller.ts
@@ -13,10 +13,16 @@ import {
 } from '@nestjs/common';
 import { TradesService } from './trade.service';
 import {
-  AuthorizeTradeDto,
+  ConfirmChainActionResponseDto,
   ConfirmTradeActionDto,
   CreateTradeDto,
+  CreateTradeRequestContractResponseDto,
+  ListTradesResponseDto,
+  LockForOrderResponseDto,
   QueryTradesDto,
+  TradeResponseDto,
+  UnlockOrderResponseDto,
+  UnlockTradeDto,
 } from './dto/trade.dto';
 import type { Request } from 'express';
 import { UserJwtGuard } from '../../common/guards/user-jwt.guard';
@@ -27,15 +33,15 @@ import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 export class TradesController {
   constructor(private readonly trades: TradesService) {}
 
-  @Get()
+  @Get('all')
   @HttpCode(HttpStatus.OK)
-  list(@Query() query: QueryTradesDto) {
+  list(@Query() query: QueryTradesDto): Promise<ListTradesResponseDto> {
     return this.trades.list(query);
   }
 
   @Get(':id')
   @HttpCode(HttpStatus.OK)
-  get(@Param('id', new ParseUUIDPipe()) id: string) {
+  get(@Param('id', new ParseUUIDPipe()) id: string): Promise<TradeResponseDto> {
     return this.trades.getById(id);
   }
 
@@ -43,40 +49,46 @@ export class TradesController {
   @Post(':id/lock')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.OK)
-  lock(@Param('id', new ParseUUIDPipe()) id: string, @Req() req: Request) {
+  lock(
+    @Req() req: Request,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<LockForOrderResponseDto> {
     return this.trades.lockTrade(req, id);
   }
 
   @ApiBearerAuth()
-  @Post()
+  @Post('create')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.CREATED)
-  async create(@Req() req: Request, @Body() dto: CreateTradeDto) {
+  async create(
+    @Req() req: Request,
+    @Body() dto: CreateTradeDto,
+  ): Promise<CreateTradeRequestContractResponseDto> {
     return this.trades.create(req, dto);
   }
 
   @ApiBearerAuth()
-  @Post(':id/authorize')
+  @Post(':id/unlock')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.OK)
-  authorize(
+  unlock(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
-    @Body() dto: AuthorizeTradeDto,
-  ) {
-    return this.trades.authorize(req, id, dto);
+    @Body() dto: UnlockTradeDto,
+  ): Promise<UnlockOrderResponseDto> {
+    return this.trades.unlock(req, id, dto);
   }
 
   @ApiBearerAuth()
-  @Post(':id/authorize/confirm')
+  @Post(':id/unlock/confirm')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.OK)
-  confirmAuthorization(
+  confirmUnlockChainAction(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: ConfirmTradeActionDto,
-  ) {
-    return this.trades.confirmAuthorizeAction(req, id, dto);
+  ): Promise<ConfirmChainActionResponseDto> {
+    return this.trades.confirmUnlockChainAction(req, id, dto);
   }
 
   @ApiBearerAuth()
@@ -87,7 +99,7 @@ export class TradesController {
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: ConfirmTradeActionDto,
-  ) {
+  ): Promise<ConfirmChainActionResponseDto> {
     return this.trades.confirmChainAction(req, id, dto);
   }
 }

--- a/apps/backend-relayer/src/modules/user/dto/user.dto.ts
+++ b/apps/backend-relayer/src/modules/user/dto/user.dto.ts
@@ -1,0 +1,7 @@
+export class UserResponseDto {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  username: string;
+  walletAddress: string;
+}

--- a/apps/backend-relayer/src/modules/user/user.controller.ts
+++ b/apps/backend-relayer/src/modules/user/user.controller.ts
@@ -10,6 +10,7 @@ import { UserService } from './user.service';
 import { UserJwtGuard } from '../../common/guards/user-jwt.guard';
 import type { Request } from 'express';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { UserResponseDto } from './dto/user.dto';
 
 @ApiTags('User')
 @Controller('v1/user')
@@ -20,7 +21,7 @@ export class UserController {
   @Get('me')
   @UseGuards(UserJwtGuard)
   @HttpCode(HttpStatus.OK)
-  getUser(@Req() req: Request) {
+  getUser(@Req() req: Request): Promise<UserResponseDto> {
     return this.users.getUser(req);
   }
 }

--- a/apps/backend-relayer/src/providers/viem/types.ts
+++ b/apps/backend-relayer/src/providers/viem/types.ts
@@ -10,13 +10,13 @@ export type T_CreateAdRequest = {
 export type T_CreateAdRequestContractDetails = {
   contractAddress: string;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   adId: string;
   adToken: `0x${string}`;
   orderChainId: string;
   adRecipient: `0x${string}`;
-  msgHash: `0x${string}`;
+  reqHash: `0x${string}`;
 };
 
 export type T_CreatFundAdRequest = {
@@ -29,11 +29,11 @@ export type T_CreatFundAdRequest = {
 export type T_CreatFundAdRequestContractDetails = {
   contractAddress: string;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   adId: string;
   amount: string;
-  msgHash: `0x${string}`;
+  reqHash: `0x${string}`;
 };
 
 export type T_WithdrawFromAdRequest = {
@@ -47,12 +47,12 @@ export type T_WithdrawFromAdRequest = {
 export type T_WithdrawFromAdRequestContractDetails = {
   contractAddress: string;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   adId: string;
   amount: string;
   to: `0x${string}`;
-  msgHash: `0x${string}`;
+  reqHash: `0x${string}`;
 };
 
 export type T_CloseAdRequest = {
@@ -65,11 +65,11 @@ export type T_CloseAdRequest = {
 export type T_CloseAdRequestContractDetails = {
   contractAddress: string;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   adId: string;
   to: `0x${string}`;
-  msgHash: `0x${string}`;
+  reqHash: `0x${string}`;
 };
 
 export type T_OrderParams = {
@@ -124,7 +124,7 @@ export type T_LockForOrderRequest = {
 export type T_LockForOrderRequestContractDetails = {
   contractAddress: string;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   orderParams: T_AdManagerOrderParams;
   reqHash: `0x${string}`;
@@ -149,7 +149,7 @@ export type T_CreateUnlockOrderContractDetails = {
 export type T_UnlockOrderContractDetails = {
   contractAddress: `0x${string}`;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   orderParams: T_OrderParams;
   nullifierHash: string;
@@ -162,7 +162,7 @@ export type T_UnlockOrderContractDetails = {
 export type T_CreateOrderRequestContractDetails = {
   contractAddress: string;
   signature: `0x${string}`;
-  token: string;
+  authToken: string;
   timeToExpire: number;
   orderParams: T_OrderPortalParams;
   orderHash: `0x${string}`;
@@ -172,7 +172,7 @@ export type T_CreateOrderRequestContractDetails = {
 export type T_RequestValidation = {
   chainId: bigint;
   contractAddress: `0x${string}`;
-  msgHash: `0x${string}`;
+  reqHash: `0x${string}`;
 };
 
 export type T_FetchRoot = {

--- a/apps/backend-relayer/src/providers/viem/viem.service.ts
+++ b/apps/backend-relayer/src/providers/viem/viem.service.ts
@@ -116,16 +116,17 @@ export class ViemService {
     const signature = await wallet.signMessage({
       message: { raw: message },
     });
+
     return {
       contractAddress: adContractAddress,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       adId,
       adToken,
       orderChainId: orderChainId.toString(),
       adRecipient,
-      msgHash: message,
+      reqHash: message,
     };
   }
 
@@ -156,11 +157,11 @@ export class ViemService {
     return {
       contractAddress: adContractAddress,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       adId,
       amount,
-      msgHash: message,
+      reqHash: message,
     };
   }
 
@@ -191,12 +192,12 @@ export class ViemService {
     return {
       contractAddress: adContractAddress,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       adId,
       amount,
       to,
-      msgHash: message,
+      reqHash: message,
     };
   }
 
@@ -228,11 +229,11 @@ export class ViemService {
     return {
       contractAddress: adContractAddress,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       adId,
       to,
-      msgHash: message,
+      reqHash: message,
     };
   }
 
@@ -265,7 +266,7 @@ export class ViemService {
     return {
       contractAddress: orderParams.adManager,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       orderParams,
       reqHash: message,
@@ -303,7 +304,7 @@ export class ViemService {
     return {
       contractAddress: orderParams.orderPortal,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       orderParams,
       reqHash: message,
@@ -312,7 +313,7 @@ export class ViemService {
   }
 
   async validateAdManagerRequest(data: T_RequestValidation): Promise<boolean> {
-    const { chainId, contractAddress, msgHash } = data;
+    const { chainId, contractAddress, reqHash } = data;
 
     const { client } = this.getClient(chainId.toString());
 
@@ -320,7 +321,7 @@ export class ViemService {
       address: contractAddress,
       abi: AD_MANAGER_ABI,
       functionName: 'checkRequestHashExists',
-      args: [msgHash],
+      args: [reqHash],
     });
 
     if (recorded) {
@@ -333,7 +334,7 @@ export class ViemService {
   async validateOrderPortalRequest(
     data: T_RequestValidation,
   ): Promise<boolean> {
-    const { chainId, contractAddress, msgHash } = data;
+    const { chainId, contractAddress, reqHash } = data;
 
     const { client } = this.getClient(chainId.toString());
 
@@ -341,7 +342,7 @@ export class ViemService {
       address: contractAddress,
       abi: ORDER_PORTAL_ABI,
       functionName: 'checkRequestHashExists',
-      args: [msgHash],
+      args: [reqHash],
     });
 
     if (recorded) {
@@ -431,7 +432,7 @@ export class ViemService {
     return {
       contractAddress,
       signature,
-      token,
+      authToken: token,
       timeToExpire: Number(timeToExpire),
       orderParams,
       nullifierHash,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized API responses across Ads, Chains, Routes, Tokens, Trades, and Users with richer, typed payloads and pagination.
- Refactor
  - Trades API renamed authorize → unlock; new endpoints: GET /all, POST /create, POST /:id/unlock, and confirm routes updated.
  - Ads routes adjusted: PATCH /:id/update and POST /:id/close.
  - Contract detail response fields renamed to authToken and reqHash.
- Bug Fixes
  - Closing an already closed ad now returns a clear error.
- Chores
  - Improved encryption robustness and key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->