### PR TITLE
feat: update ad query dtos to include chainids

### DIFF
--- a/apps/backend-relayer/src/modules/ads/ad.service.ts
+++ b/apps/backend-relayer/src/modules/ads/ad.service.ts
@@ -23,6 +23,8 @@ type AdQueryInput = {
   routeId?: string;
   creatorAddress?: string;
   status?: AdStatus;
+  adChainId?: bigint;
+  orderChainId?: bigint;
 };
 
 type AdUpdateInput = {
@@ -56,7 +58,17 @@ export class AdsService {
     if (query.status) where.status = query.status;
 
     const items = await this.prisma.ad.findMany({
-      where,
+      where: {
+        ...where,
+        adToken: {
+          chain: query.adChainId ? { chainId: query.adChainId } : undefined,
+        },
+        orderToken: {
+          chain: query.orderChainId
+            ? { chainId: query.orderChainId }
+            : undefined,
+        },
+      },
       orderBy: { id: 'asc' },
       take: take + 1,
       ...(cursor ? { cursor, skip: 1 } : {}),

--- a/apps/backend-relayer/src/modules/ads/dto/ad.dto.ts
+++ b/apps/backend-relayer/src/modules/ads/dto/ad.dto.ts
@@ -23,6 +23,18 @@ export class QueryAdsDto {
   creatorAddress?: string;
 
   @ApiPropertyOptional({
+    description: 'Chain ID of the ad token',
+    example: 1,
+  })
+  adChainId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Chain ID of the order token',
+    example: 298,
+  })
+  orderChainId?: number;
+
+  @ApiPropertyOptional({
     enum: ['ACTIVE', 'PAUSED', 'EXHAUSTED', 'CLOSED'],
     description: 'Current status of the ad',
     example: 'ACTIVE',
@@ -34,8 +46,7 @@ export class QueryAdsDto {
 
   @ApiPropertyOptional({
     description: 'Pagination cursor',
-    example:
-      'eyJpZCI6IjEyMyIsImNyZWF0ZWRBdCI6IjIwMjMtMDEtMDFUMDA6MDA6MDAuMDAwWiJ9',
+    example: '5',
   })
   @IsOptional()
   @IsString()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ads listing API now supports optional adChainId and orderChainId filters to narrow results by token chain ID.
* **Documentation**
  * API docs updated to include the new filters and a simplified example for the pagination cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->