### PR TITLE
feat: extend ad response to include adToken and orderToken details

### DIFF
--- a/apps/backend-relayer/src/modules/ads/ad.service.ts
+++ b/apps/backend-relayer/src/modules/ads/ad.service.ts
@@ -81,10 +81,29 @@ export class AdsService {
         poolAmount: true,
         minAmount: true,
         maxAmount: true,
+        adToken: {
+          select: {
+            chain: { select: { chainId: true } },
+            address: true,
+            symbol: true,
+            name: true,
+            decimals: true,
+          },
+        },
+        orderToken: {
+          select: {
+            chain: { select: { chainId: true } },
+            address: true,
+            symbol: true,
+            name: true,
+            decimals: true,
+          },
+        },
         status: true,
         metadata: true,
         createdAt: true,
         updatedAt: true,
+        route: true,
       },
     });
 
@@ -137,6 +156,20 @@ export class AdsService {
         metadata: i.metadata ?? null,
         createdAt: i.createdAt.toISOString(),
         updatedAt: i.updatedAt.toISOString(),
+        adToken: {
+          name: i.adToken.name,
+          symbol: i.adToken.symbol,
+          address: i.adToken.address,
+          decimals: i.adToken.decimals,
+          chainId: i.adToken.chain.chainId.toString(),
+        },
+        orderToken: {
+          name: i.orderToken.name,
+          symbol: i.orderToken.symbol,
+          address: i.orderToken.address,
+          decimals: i.orderToken.decimals,
+          chainId: i.orderToken.chain.chainId.toString(),
+        },
       };
     });
 
@@ -157,6 +190,24 @@ export class AdsService {
         maxAmount: true,
         status: true,
         metadata: true,
+        adToken: {
+          select: {
+            chain: { select: { chainId: true } },
+            address: true,
+            symbol: true,
+            name: true,
+            decimals: true,
+          },
+        },
+        orderToken: {
+          select: {
+            chain: { select: { chainId: true } },
+            address: true,
+            symbol: true,
+            name: true,
+            decimals: true,
+          },
+        },
         createdAt: true,
         updatedAt: true,
       },
@@ -190,6 +241,20 @@ export class AdsService {
       minAmount: ad.minAmount ? ad.minAmount.toString() : null,
       maxAmount: ad.maxAmount ? ad.maxAmount.toString() : null,
       status: ad.status != 'INACTIVE' ? effectiveStatus : ad.status,
+      adToken: {
+        name: ad.adToken.name,
+        symbol: ad.adToken.symbol,
+        address: ad.adToken.address,
+        decimals: ad.adToken.decimals,
+        chainId: ad.adToken.chain.chainId.toString(),
+      },
+      orderToken: {
+        name: ad.orderToken.name,
+        symbol: ad.orderToken.symbol,
+        address: ad.orderToken.address,
+        decimals: ad.orderToken.decimals,
+        chainId: ad.orderToken.chain.chainId.toString(),
+      },
       metadata: ad.metadata ?? null,
       createdAt: ad.createdAt.toISOString(),
       updatedAt: ad.updatedAt.toISOString(),

--- a/apps/backend-relayer/src/modules/ads/dto/ad.dto.ts
+++ b/apps/backend-relayer/src/modules/ads/dto/ad.dto.ts
@@ -198,6 +198,19 @@ export class ConfirmAdActionDto {
   signature?: string;
 }
 
+export class TokenDto {
+  @ApiProperty({ type: String, description: 'Token name' })
+  name!: string;
+  @ApiProperty({ type: String, description: 'Token symbol' })
+  symbol!: string;
+  @ApiProperty({ type: String, description: 'Token contract address' })
+  address!: string;
+  @ApiProperty({ type: String, description: 'Token decimal places' })
+  decimals!: number;
+  @ApiProperty({ type: String, description: 'Blockchain chain ID' })
+  chainId!: string;
+}
+
 export class AdResponseDto {
   @ApiProperty({
     type: String,
@@ -260,6 +273,12 @@ export class AdResponseDto {
     description: 'Additional custom metadata associated with the ad',
   })
   metadata!: string | number | boolean | JsonObject | JsonArray | null;
+
+  @ApiProperty({ type: TokenDto, description: 'Details of the ad token' })
+  adToken!: TokenDto;
+
+  @ApiProperty({ type: TokenDto, description: 'Details of the order token' })
+  orderToken!: TokenDto;
 
   @ApiProperty({ description: 'Timestamp when the ad entry was created' })
   createdAt!: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ad list and detail responses now include full token metadata for both adToken and orderToken: name, symbol, address, decimals, and chainId.
  - Route information is now included in ad list results.

- Enhancements
  - Standardized token details via a dedicated token data structure for consistent API responses.
  - chainId values are returned as strings for improved interoperability across clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->