### PR TITLE
chore: refactor backend relayer to reflect contract update for evm addresses

### DIFF
--- a/apps/backend-relayer/package.json
+++ b/apps/backend-relayer/package.json
@@ -34,7 +34,7 @@
     "@noble/curves": "^2.0.0",
     "@node-rs/argon2": "^2.0.2",
     "@noir-lang/noir_js": "1.0.0-beta.9",
-    "@prisma/client": "7.7.0",
+    "@prisma/client": "6.16.1",
     "@types/morgan": "^1.9.10",
     "@zkpassport/poseidon2": "^0.6.2",
     "abstract-level": "^3.1.0",

--- a/apps/backend-relayer/src/modules/ads/ad.service.ts
+++ b/apps/backend-relayer/src/modules/ads/ad.service.ts
@@ -20,6 +20,7 @@ import { getAddress } from 'viem';
 import { AdStatus, Prisma } from '@prisma/client';
 import { Request } from 'express';
 import { ViemService } from '../../providers/viem/viem.service';
+import { toBytes32 } from '../../providers/viem/ethers/typedData';
 import { randomUUID } from 'crypto';
 
 type AdQueryInput = {
@@ -395,7 +396,7 @@ export class AdsService {
           orderChainId: route.orderToken.chain.chainId,
           adToken: route.adToken.address as `0x${string}`,
           initialAmount: fundAmount.toFixed(0),
-          adRecipient: dto.creatorDstAddress as `0x${string}`,
+          adRecipient: toBytes32(dto.creatorDstAddress),
         });
 
       const requestDetails = await this.prisma.$transaction(async (prisma) => {

--- a/apps/backend-relayer/src/modules/trades/trade.service.ts
+++ b/apps/backend-relayer/src/modules/trades/trade.service.ts
@@ -22,7 +22,7 @@ import { ProofService } from '../../providers/noir/proof.service';
 import { randomUUID } from 'crypto';
 import { Prisma, TradeStatus } from '@prisma/client';
 import { EncryptionService } from '@libs/encryption.service';
-import { uuidToBigInt } from '../../providers/viem/ethers/typedData';
+import { toBytes32, uuidToBigInt } from '../../providers/viem/ethers/typedData';
 
 @Injectable()
 export class TradesService {
@@ -369,19 +369,23 @@ export class TradesService {
       const reqContractDetails =
         await this.viemService.getCreateOrderRequestContractDetails({
           orderChainId: ad.route.orderToken.chain.chainId,
+          orderContractAddress: ad.route.orderToken.chain
+            .orderPortalAddress as `0x${string}`,
           orderParams: {
-            orderChainToken: ad.route.orderToken.address,
-            adChainToken: ad.route.adToken.address,
+            orderChainToken: toBytes32(ad.route.orderToken.address),
+            adChainToken: toBytes32(ad.route.adToken.address),
             amount: amount.toFixed(0),
-            bridger: getAddress(user.walletAddress),
+            bridger: toBytes32(user.walletAddress),
             orderChainId: ad.route.orderToken.chain.chainId.toString(),
-            orderPortal: ad.route.orderToken.chain.orderPortalAddress,
-            orderRecipient: getAddress(dto.bridgerDstAddress),
+            orderPortal: toBytes32(
+              ad.route.orderToken.chain.orderPortalAddress,
+            ),
+            orderRecipient: toBytes32(dto.bridgerDstAddress),
             adChainId: ad.route.adToken.chain.chainId.toString(),
-            adManager: ad.route.adToken.chain.adManagerAddress,
+            adManager: toBytes32(ad.route.adToken.chain.adManagerAddress),
             adId: ad.id,
-            adCreator: getAddress(ad.creatorAddress),
-            adRecipient: getAddress(ad.creatorDstAddress),
+            adCreator: toBytes32(ad.creatorAddress),
+            adRecipient: toBytes32(ad.creatorDstAddress),
             salt: tradeId,
           },
         });
@@ -642,21 +646,23 @@ export class TradesService {
       const reqContractDetails =
         await this.viemService.getLockForOrderRequestContractDetails({
           adChainId: trade.route.adToken.chain.chainId,
+          adContractAddress: trade.route.adToken.chain
+            .adManagerAddress as `0x${string}`,
           orderParams: {
-            orderChainToken: getAddress(trade.route.orderToken.address),
-            adChainToken: getAddress(trade.route.adToken.address),
+            orderChainToken: toBytes32(trade.route.orderToken.address),
+            adChainToken: toBytes32(trade.route.adToken.address),
             amount: trade.amount.toFixed(0),
-            bridger: getAddress(trade.bridgerAddress),
+            bridger: toBytes32(trade.bridgerAddress),
             orderChainId: trade.route.orderToken.chain.chainId.toString(),
-            orderPortal: getAddress(
+            orderPortal: toBytes32(
               trade.route.orderToken.chain.orderPortalAddress,
             ),
-            orderRecipient: getAddress(trade.bridgerDstAddress),
+            orderRecipient: toBytes32(trade.bridgerDstAddress),
             adChainId: trade.route.adToken.chain.chainId.toString(),
-            adManager: getAddress(trade.route.adToken.chain.adManagerAddress),
+            adManager: toBytes32(trade.route.adToken.chain.adManagerAddress),
             adId: trade.adId,
-            adCreator: getAddress(trade.adCreatorAddress),
-            adRecipient: getAddress(trade.adCreatorDstAddress),
+            adCreator: toBytes32(trade.adCreatorAddress),
+            adRecipient: toBytes32(trade.adCreatorDstAddress),
             salt: trade.id,
           },
         });
@@ -872,20 +878,20 @@ export class TradesService {
             : (trade.route.adToken.chain.adManagerAddress as `0x${string}`),
           isAdCreator,
           orderParams: {
-            orderChainToken: trade.route.orderToken.address as `0x${string}`,
-            adChainToken: trade.route.adToken.address as `0x${string}`,
+            orderChainToken: toBytes32(trade.route.orderToken.address),
+            adChainToken: toBytes32(trade.route.adToken.address),
             amount: trade.amount.toFixed(0),
-            bridger: getAddress(trade.bridgerAddress),
+            bridger: toBytes32(trade.bridgerAddress),
             orderChainId: trade.route.orderToken.chain.chainId.toString(),
-            orderPortal: trade.route.orderToken.chain
-              .orderPortalAddress as `0x${string}`,
-            orderRecipient: getAddress(trade.bridgerDstAddress),
+            orderPortal: toBytes32(
+              trade.route.orderToken.chain.orderPortalAddress,
+            ),
+            orderRecipient: toBytes32(trade.bridgerDstAddress),
             adChainId: trade.route.adToken.chain.chainId.toString(),
-            adManager: trade.route.adToken.chain
-              .adManagerAddress as `0x${string}`,
+            adManager: toBytes32(trade.route.adToken.chain.adManagerAddress),
             adId: trade.adId,
-            adCreator: getAddress(trade.adCreatorAddress),
-            adRecipient: getAddress(trade.adCreatorDstAddress),
+            adCreator: toBytes32(trade.adCreatorAddress),
+            adRecipient: toBytes32(trade.adCreatorDstAddress),
             salt: trade.id,
           },
           nullifierHash: nullifierHash,

--- a/apps/backend-relayer/src/providers/viem/abis/adManager.abi.ts
+++ b/apps/backend-relayer/src/providers/viem/abis/adManager.abi.ts
@@ -2,7 +2,11 @@ export const AD_MANAGER_ABI = [
   {
     type: 'constructor',
     inputs: [
-      { name: 'admin', type: 'address', internalType: 'address' },
+      {
+        name: 'admin',
+        type: 'address',
+        internalType: 'address',
+      },
       {
         name: '_verifier',
         type: 'address',
@@ -21,98 +25,238 @@ export const AD_MANAGER_ABI = [
     ],
     stateMutability: 'nonpayable',
   },
-  { type: 'fallback', stateMutability: 'payable' },
-  { type: 'receive', stateMutability: 'payable' },
+  {
+    type: 'fallback',
+    stateMutability: 'payable',
+  },
+  {
+    type: 'receive',
+    stateMutability: 'payable',
+  },
   {
     type: 'function',
     name: 'ADMIN_ROLE',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'DEFAULT_ADMIN_ROLE',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'DOMAIN_TYPEHASH_MIN',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'NATIVE_TOKEN_ADDRESS',
     inputs: [],
-    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'ORDER_TYPEHASH',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'adIds',
-    inputs: [{ name: '', type: 'string', internalType: 'string' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'ads',
-    inputs: [{ name: '', type: 'string', internalType: 'string' }],
+    inputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
     outputs: [
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'adRecipient', type: 'address', internalType: 'address' },
-      { name: 'maker', type: 'address', internalType: 'address' },
-      { name: 'token', type: 'address', internalType: 'address' },
-      { name: 'balance', type: 'uint256', internalType: 'uint256' },
-      { name: 'locked', type: 'uint256', internalType: 'uint256' },
-      { name: 'open', type: 'bool', internalType: 'bool' },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adRecipient',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'maker',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'balance',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'locked',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'open',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'availableLiquidity',
-    inputs: [{ name: 'adId', type: 'string', internalType: 'string' }],
-    outputs: [{ name: 'amount', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    outputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'chains',
-    inputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     outputs: [
-      { name: 'supported', type: 'bool', internalType: 'bool' },
-      { name: 'orderPortal', type: 'address', internalType: 'address' },
+      {
+        name: 'supported',
+        type: 'bool',
+        internalType: 'bool',
+      },
+      {
+        name: 'orderPortal',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'checkRequestHashExists',
-    inputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'closeAd',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'to', type: 'address', internalType: 'address' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'payable',
@@ -121,26 +265,80 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'closeAdRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'to', type: 'address', internalType: 'address' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'createAd',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'adToken', type: 'address', internalType: 'address' },
-      { name: 'initialAmount', type: 'uint256', internalType: 'uint256' },
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'adRecipient', type: 'address', internalType: 'address' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'adToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'initialAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adRecipient',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     outputs: [],
     stateMutability: 'payable',
@@ -149,15 +347,49 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'createAdRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'adToken', type: 'address', internalType: 'address' },
-      { name: 'initialAmount', type: 'uint256', internalType: 'uint256' },
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'adRecipient', type: 'address', internalType: 'address' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'adToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'initialAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adRecipient',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
@@ -165,13 +397,41 @@ export const AD_MANAGER_ABI = [
     name: 'eip712Domain',
     inputs: [],
     outputs: [
-      { name: 'fields', type: 'bytes1', internalType: 'bytes1' },
-      { name: 'name', type: 'string', internalType: 'string' },
-      { name: 'version', type: 'string', internalType: 'string' },
-      { name: 'chainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'verifyingContract', type: 'address', internalType: 'address' },
-      { name: 'salt', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'extensions', type: 'uint256[]', internalType: 'uint256[]' },
+      {
+        name: 'fields',
+        type: 'bytes1',
+        internalType: 'bytes1',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'version',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'chainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'verifyingContract',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'salt',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'extensions',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
     ],
     stateMutability: 'view',
   },
@@ -179,11 +439,31 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'fundAd',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'amount', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
     outputs: [],
     stateMutability: 'payable',
@@ -192,65 +472,151 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'fundAdRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'amount', type: 'uint256', internalType: 'uint256' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getChainID',
     inputs: [],
-    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getHistoricalRoot',
-    inputs: [{ name: 'index', type: 'uint256', internalType: 'uint256' }],
-    outputs: [{ name: 'root', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'index',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'root',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getLatestMerkleRoot',
     inputs: [],
-    outputs: [{ name: 'root', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'root',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getMerkleLeafCount',
     inputs: [],
-    outputs: [{ name: 'count', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      {
+        name: 'count',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getRoleAdmin',
-    inputs: [{ name: 'role', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getSigner',
     inputs: [
-      { name: 'message', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
     stateMutability: 'pure',
   },
   {
     type: 'function',
     name: 'grantRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -259,22 +625,58 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'hasRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'hashRequest',
     inputs: [
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
-      { name: '_action', type: 'string', internalType: 'string' },
-      { name: '_params', type: 'bytes[]', internalType: 'bytes[]' },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_action',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: '_params',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
     ],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
@@ -282,7 +684,11 @@ export const AD_MANAGER_ABI = [
     name: 'i_merkleManager',
     inputs: [],
     outputs: [
-      { name: '', type: 'address', internalType: 'contract IMerkleManager' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract IMerkleManager',
+      },
     ],
     stateMutability: 'view',
   },
@@ -291,7 +697,11 @@ export const AD_MANAGER_ABI = [
     name: 'i_verifier',
     inputs: [],
     outputs: [
-      { name: '', type: 'address', internalType: 'contract IVerifier' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract IVerifier',
+      },
     ],
     stateMutability: 'view',
   },
@@ -299,63 +709,181 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'lockForOrder',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
       {
         name: 'params',
         type: 'tuple',
         internalType: 'struct AdManager.OrderParams',
         components: [
-          { name: 'orderChainToken', type: 'address', internalType: 'address' },
-          { name: 'adChainToken', type: 'address', internalType: 'address' },
-          { name: 'amount', type: 'uint256', internalType: 'uint256' },
-          { name: 'bridger', type: 'address', internalType: 'address' },
-          { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
-          { name: 'srcOrderPortal', type: 'address', internalType: 'address' },
-          { name: 'orderRecipient', type: 'address', internalType: 'address' },
-          { name: 'adId', type: 'string', internalType: 'string' },
-          { name: 'adCreator', type: 'address', internalType: 'address' },
-          { name: 'adRecipient', type: 'address', internalType: 'address' },
-          { name: 'salt', type: 'uint256', internalType: 'uint256' },
+          {
+            name: 'orderChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'bridger',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'orderChainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'srcOrderPortal',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'orderRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adId',
+            type: 'string',
+            internalType: 'string',
+          },
+          {
+            name: 'adCreator',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'salt',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
         ],
       },
     ],
-    outputs: [{ name: 'orderHash', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'nonpayable',
   },
   {
     type: 'function',
     name: 'lockForOrderRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'orderHash', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'managers',
-    inputs: [{ name: '', type: 'address', internalType: 'address' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'nullifierUsed',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'orders',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     outputs: [
-      { name: '', type: 'uint8', internalType: 'enum AdManager.Status' },
+      {
+        name: '',
+        type: 'uint8',
+        internalType: 'enum AdManager.Status',
+      },
     ],
     stateMutability: 'view',
   },
@@ -363,7 +891,11 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'removeChain',
     inputs: [
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -372,8 +904,16 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'removeTokenRoute',
     inputs: [
-      { name: 'adToken', type: 'address', internalType: 'address' },
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -382,8 +922,16 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'renounceRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'callerConfirmation', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'callerConfirmation',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -391,23 +939,55 @@ export const AD_MANAGER_ABI = [
   {
     type: 'function',
     name: 'requestHashes',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'requestTokens',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'revokeRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -416,9 +996,21 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'setChain',
     inputs: [
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'orderPortal', type: 'address', internalType: 'address' },
-      { name: 'supported', type: 'bool', internalType: 'bool' },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'orderPortal',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'supported',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -427,8 +1019,16 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'setManager',
     inputs: [
-      { name: '_manager', type: 'address', internalType: 'address' },
-      { name: '_status', type: 'bool', internalType: 'bool' },
+      {
+        name: '_manager',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_status',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -437,9 +1037,21 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'setTokenRoute',
     inputs: [
-      { name: 'adToken', type: 'address', internalType: 'address' },
-      { name: 'orderToken', type: 'address', internalType: 'address' },
-      { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'orderToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'orderChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -447,48 +1059,142 @@ export const AD_MANAGER_ABI = [
   {
     type: 'function',
     name: 'supportsInterface',
-    inputs: [{ name: 'interfaceId', type: 'bytes4', internalType: 'bytes4' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: 'interfaceId',
+        type: 'bytes4',
+        internalType: 'bytes4',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'tokenRoute',
     inputs: [
-      { name: '', type: 'address', internalType: 'address' },
-      { name: '', type: 'uint256', internalType: 'uint256' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'unlock',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
       {
         name: 'params',
         type: 'tuple',
         internalType: 'struct AdManager.OrderParams',
         components: [
-          { name: 'orderChainToken', type: 'address', internalType: 'address' },
-          { name: 'adChainToken', type: 'address', internalType: 'address' },
-          { name: 'amount', type: 'uint256', internalType: 'uint256' },
-          { name: 'bridger', type: 'address', internalType: 'address' },
-          { name: 'orderChainId', type: 'uint256', internalType: 'uint256' },
-          { name: 'srcOrderPortal', type: 'address', internalType: 'address' },
-          { name: 'orderRecipient', type: 'address', internalType: 'address' },
-          { name: 'adId', type: 'string', internalType: 'string' },
-          { name: 'adCreator', type: 'address', internalType: 'address' },
-          { name: 'adRecipient', type: 'address', internalType: 'address' },
-          { name: 'salt', type: 'uint256', internalType: 'uint256' },
+          {
+            name: 'orderChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'bridger',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'orderChainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'srcOrderPortal',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'orderRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adId',
+            type: 'string',
+            internalType: 'string',
+          },
+          {
+            name: 'adCreator',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'salt',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
         ],
       },
-      { name: 'nullifierHash', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'targetRoot', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'proof', type: 'bytes', internalType: 'bytes' },
+      {
+        name: 'nullifierHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'targetRoot',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'proof',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
     outputs: [],
     stateMutability: 'payable',
@@ -497,13 +1203,39 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'unlockOrderRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'orderHash', type: 'bytes32', internalType: 'bytes32' },
-      { name: '_targetRoot', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: '_targetRoot',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
@@ -511,7 +1243,11 @@ export const AD_MANAGER_ABI = [
     name: 'wNativeToken',
     inputs: [],
     outputs: [
-      { name: '', type: 'address', internalType: 'contract IwNativeToken' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract IwNativeToken',
+      },
     ],
     stateMutability: 'view',
   },
@@ -519,12 +1255,36 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'withdrawFromAd',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'amount', type: 'uint256', internalType: 'uint256' },
-      { name: 'to', type: 'address', internalType: 'address' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'payable',
@@ -533,20 +1293,51 @@ export const AD_MANAGER_ABI = [
     type: 'function',
     name: 'withdrawFromAdRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'amount', type: 'uint256', internalType: 'uint256' },
-      { name: 'to', type: 'address', internalType: 'address' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'event',
     name: 'AdClosed',
     inputs: [
-      { name: 'adId', type: 'string', indexed: true, internalType: 'string' },
+      {
+        name: 'adId',
+        type: 'string',
+        indexed: true,
+        internalType: 'string',
+      },
       {
         name: 'maker',
         type: 'address',
@@ -560,7 +1351,12 @@ export const AD_MANAGER_ABI = [
     type: 'event',
     name: 'AdCreated',
     inputs: [
-      { name: 'adId', type: 'string', indexed: true, internalType: 'string' },
+      {
+        name: 'adId',
+        type: 'string',
+        indexed: true,
+        internalType: 'string',
+      },
       {
         name: 'maker',
         type: 'address',
@@ -592,7 +1388,12 @@ export const AD_MANAGER_ABI = [
     type: 'event',
     name: 'AdFunded',
     inputs: [
-      { name: 'adId', type: 'string', indexed: true, internalType: 'string' },
+      {
+        name: 'adId',
+        type: 'string',
+        indexed: true,
+        internalType: 'string',
+      },
       {
         name: 'maker',
         type: 'address',
@@ -618,7 +1419,12 @@ export const AD_MANAGER_ABI = [
     type: 'event',
     name: 'AdWithdrawn',
     inputs: [
-      { name: 'adId', type: 'string', indexed: true, internalType: 'string' },
+      {
+        name: 'adId',
+        type: 'string',
+        indexed: true,
+        internalType: 'string',
+      },
       {
         name: 'maker',
         type: 'address',
@@ -652,20 +1458,35 @@ export const AD_MANAGER_ABI = [
       },
       {
         name: 'orderPortal',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
-      { name: 'supported', type: 'bool', indexed: false, internalType: 'bool' },
+      {
+        name: 'supported',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
     ],
     anonymous: false,
   },
-  { type: 'event', name: 'EIP712DomainChanged', inputs: [], anonymous: false },
+  {
+    type: 'event',
+    name: 'EIP712DomainChanged',
+    inputs: [],
+    anonymous: false,
+  },
   {
     type: 'event',
     name: 'OrderLocked',
     inputs: [
-      { name: 'adId', type: 'string', indexed: true, internalType: 'string' },
+      {
+        name: 'adId',
+        type: 'string',
+        indexed: true,
+        internalType: 'string',
+      },
       {
         name: 'orderHash',
         type: 'bytes32',
@@ -692,15 +1513,15 @@ export const AD_MANAGER_ABI = [
       },
       {
         name: 'bridger',
-        type: 'address',
+        type: 'bytes32',
         indexed: false,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'recipient',
-        type: 'address',
+        type: 'bytes32',
         indexed: false,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
     ],
     anonymous: false,
@@ -717,9 +1538,9 @@ export const AD_MANAGER_ABI = [
       },
       {
         name: 'recipient',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'nullifierHash',
@@ -734,7 +1555,12 @@ export const AD_MANAGER_ABI = [
     type: 'event',
     name: 'RoleAdminChanged',
     inputs: [
-      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
       {
         name: 'previousAdminRole',
         type: 'bytes32',
@@ -754,7 +1580,12 @@ export const AD_MANAGER_ABI = [
     type: 'event',
     name: 'RoleGranted',
     inputs: [
-      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
       {
         name: 'account',
         type: 'address',
@@ -774,7 +1605,12 @@ export const AD_MANAGER_ABI = [
     type: 'event',
     name: 'RoleRevoked',
     inputs: [
-      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
       {
         name: 'account',
         type: 'address',
@@ -802,12 +1638,12 @@ export const AD_MANAGER_ABI = [
       },
       {
         name: 'orderChainToken',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
-        name: 'adChainId',
+        name: 'orderChainId',
         type: 'uint256',
         indexed: true,
         internalType: 'uint256',
@@ -820,22 +1656,22 @@ export const AD_MANAGER_ABI = [
     name: 'TokenRouteSet',
     inputs: [
       {
-        name: 'orderChainToken',
+        name: 'adToken',
         type: 'address',
         indexed: true,
         internalType: 'address',
       },
       {
-        name: 'adChainId',
+        name: 'orderChainId',
         type: 'uint256',
         indexed: true,
         internalType: 'uint256',
       },
       {
-        name: 'adChainToken',
-        type: 'address',
+        name: 'orderChainToken',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
     ],
     anonymous: false,
@@ -850,129 +1686,339 @@ export const AD_MANAGER_ABI = [
         indexed: true,
         internalType: 'address',
       },
-      { name: 'status', type: 'bool', indexed: false, internalType: 'bool' },
+      {
+        name: 'status',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
     ],
     anonymous: false,
   },
-  { type: 'error', name: 'AccessControlBadConfirmation', inputs: [] },
+  {
+    type: 'error',
+    name: 'AccessControlBadConfirmation',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'AccessControlUnauthorizedAccount',
     inputs: [
-      { name: 'account', type: 'address', internalType: 'address' },
-      { name: 'neededRole', type: 'bytes32', internalType: 'bytes32' },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'neededRole',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
-  { type: 'error', name: 'AdManager__AdClosed', inputs: [] },
-  { type: 'error', name: 'AdManager__AdNotFound', inputs: [] },
+  {
+    type: 'error',
+    name: 'AdManager__AdClosed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__AdNotFound',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'AdManager__AdRecipientMismatch',
     inputs: [
-      { name: 'expected', type: 'address', internalType: 'address' },
-      { name: 'provided', type: 'address', internalType: 'address' },
+      {
+        name: 'expected',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'provided',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
   {
     type: 'error',
     name: 'AdManager__AdTokenMismatch',
     inputs: [
-      { name: 'expected', type: 'address', internalType: 'address' },
-      { name: 'provided', type: 'address', internalType: 'address' },
+      {
+        name: 'expected',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'provided',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
-  { type: 'error', name: 'AdManager__BridgerZero', inputs: [] },
+  {
+    type: 'error',
+    name: 'AdManager__BridgerZero',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'AdManager__ChainNotSupported',
-    inputs: [{ name: 'chainId', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: 'chainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
-  { type: 'error', name: 'AdManager__InsufficientLiquidity', inputs: [] },
-  { type: 'error', name: 'AdManager__InvalidMessage', inputs: [] },
-  { type: 'error', name: 'AdManager__InvalidProof', inputs: [] },
-  { type: 'error', name: 'AdManager__MerkleManagerAppendFailed', inputs: [] },
+  {
+    type: 'error',
+    name: 'AdManager__InsufficientLiquidity',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__InvalidMessage',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__InvalidProof',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__MerkleManagerAppendFailed',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'AdManager__MissingRoute',
     inputs: [
-      { name: 'orderChainToken', type: 'address', internalType: 'address' },
-      { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'orderChainToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
   },
-  { type: 'error', name: 'AdManager__NotMaker', inputs: [] },
+  {
+    type: 'error',
+    name: 'AdManager__NotEvmAddress',
+    inputs: [
+      {
+        name: 'value',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__NotMaker',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'AdManager__NullifierUsed',
     inputs: [
-      { name: 'nullifierHash', type: 'bytes32', internalType: 'bytes32' },
+      {
+        name: 'nullifierHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
   {
     type: 'error',
     name: 'AdManager__OrderChainMismatch',
     inputs: [
-      { name: 'expected', type: 'uint256', internalType: 'uint256' },
-      { name: 'provided', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'expected',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'provided',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
   },
   {
     type: 'error',
     name: 'AdManager__OrderExists',
-    inputs: [{ name: 'orderHash', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'AdManager__OrderNotOpen',
-    inputs: [{ name: 'orderHash', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'AdManager__OrderPortalMismatch',
     inputs: [
-      { name: 'expected', type: 'address', internalType: 'address' },
-      { name: 'provided', type: 'address', internalType: 'address' },
+      {
+        name: 'expected',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'provided',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
   {
     type: 'error',
     name: 'AdManager__OrderTokenMismatch',
     inputs: [
-      { name: 'expected', type: 'address', internalType: 'address' },
-      { name: 'provided', type: 'address', internalType: 'address' },
+      {
+        name: 'expected',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'provided',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
-  { type: 'error', name: 'AdManager__RecipientZero', inputs: [] },
-  { type: 'error', name: 'AdManager__RequestTokenExpired', inputs: [] },
-  { type: 'error', name: 'AdManager__TokenAlreadyUsed', inputs: [] },
-  { type: 'error', name: 'AdManager__TokenZeroAddress', inputs: [] },
-  { type: 'error', name: 'AdManager__UsedAdId', inputs: [] },
-  { type: 'error', name: 'AdManager__ZeroAddress', inputs: [] },
-  { type: 'error', name: 'AdManager__ZeroAmount', inputs: [] },
-  { type: 'error', name: 'Admanage__ZeroSigner', inputs: [] },
-  { type: 'error', name: 'Admanager__ActiveLocks', inputs: [] },
-  { type: 'error', name: 'Admanager__InvalidSigner', inputs: [] },
-  { type: 'error', name: 'Admanager__RequestHashedProcessed', inputs: [] },
-  { type: 'error', name: 'ECDSAInvalidSignature', inputs: [] },
+  {
+    type: 'error',
+    name: 'AdManager__RecipientZero',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__RequestTokenExpired',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__TokenAlreadyUsed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__TokenZeroAddress',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__UsedAdId',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__ZeroAddress',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'AdManager__ZeroAmount',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Admanage__ZeroSigner',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Admanager__ActiveLocks',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Admanager__InvalidSigner',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Admanager__RequestHashedProcessed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ECDSAInvalidSignature',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'ECDSAInvalidSignatureLength',
-    inputs: [{ name: 'length', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: 'length',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'ECDSAInvalidSignatureS',
-    inputs: [{ name: 's', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 's',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
-  { type: 'error', name: 'InvalidShortString', inputs: [] },
-  { type: 'error', name: 'ReentrancyGuardReentrantCall', inputs: [] },
+  {
+    type: 'error',
+    name: 'InvalidShortString',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ReentrancyGuardReentrantCall',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'SafeERC20FailedOperation',
-    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'StringTooLong',
-    inputs: [{ name: 'str', type: 'string', internalType: 'string' }],
+    inputs: [
+      {
+        name: 'str',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
   },
-];
+] as const;

--- a/apps/backend-relayer/src/providers/viem/abis/orderPortal.abi.ts
+++ b/apps/backend-relayer/src/providers/viem/abis/orderPortal.abi.ts
@@ -2,7 +2,11 @@ export const ORDER_PORTAL_ABI = [
   {
     type: 'constructor',
     inputs: [
-      { name: 'admin', type: 'address', internalType: 'address' },
+      {
+        name: 'admin',
+        type: 'address',
+        internalType: 'address',
+      },
       {
         name: '_verifier',
         type: 'address',
@@ -21,99 +25,245 @@ export const ORDER_PORTAL_ABI = [
     ],
     stateMutability: 'nonpayable',
   },
-  { type: 'fallback', stateMutability: 'payable' },
-  { type: 'receive', stateMutability: 'payable' },
+  {
+    type: 'fallback',
+    stateMutability: 'payable',
+  },
+  {
+    type: 'receive',
+    stateMutability: 'payable',
+  },
   {
     type: 'function',
     name: 'ADMIN_ROLE',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'DEFAULT_ADMIN_ROLE',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'DOMAIN_TYPEHASH_MIN',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'NATIVE_TOKEN_ADDRESS',
     inputs: [],
-    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'ORDER_TYPEHASH',
     inputs: [],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'chains',
-    inputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     outputs: [
-      { name: 'supported', type: 'bool', internalType: 'bool' },
-      { name: 'adManager', type: 'address', internalType: 'address' },
+      {
+        name: 'supported',
+        type: 'bool',
+        internalType: 'bool',
+      },
+      {
+        name: 'adManager',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'checkRequestHashExists',
-    inputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'createOrder',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
       {
         name: 'params',
         type: 'tuple',
         internalType: 'struct OrderPortal.OrderParams',
         components: [
-          { name: 'orderChainToken', type: 'address', internalType: 'address' },
-          { name: 'adChainToken', type: 'address', internalType: 'address' },
-          { name: 'amount', type: 'uint256', internalType: 'uint256' },
-          { name: 'bridger', type: 'address', internalType: 'address' },
-          { name: 'orderRecipient', type: 'address', internalType: 'address' },
-          { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
-          { name: 'adManager', type: 'address', internalType: 'address' },
-          { name: 'adId', type: 'string', internalType: 'string' },
-          { name: 'adCreator', type: 'address', internalType: 'address' },
-          { name: 'adRecipient', type: 'address', internalType: 'address' },
-          { name: 'salt', type: 'uint256', internalType: 'uint256' },
+          {
+            name: 'orderChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'bridger',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'orderRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adChainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'adManager',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adId',
+            type: 'string',
+            internalType: 'string',
+          },
+          {
+            name: 'adCreator',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'salt',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
         ],
       },
     ],
-    outputs: [{ name: 'orderHash', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'payable',
   },
   {
     type: 'function',
     name: 'createOrderRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'orderHash', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
@@ -121,13 +271,41 @@ export const ORDER_PORTAL_ABI = [
     name: 'eip712Domain',
     inputs: [],
     outputs: [
-      { name: 'fields', type: 'bytes1', internalType: 'bytes1' },
-      { name: 'name', type: 'string', internalType: 'string' },
-      { name: 'version', type: 'string', internalType: 'string' },
-      { name: 'chainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'verifyingContract', type: 'address', internalType: 'address' },
-      { name: 'salt', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'extensions', type: 'uint256[]', internalType: 'uint256[]' },
+      {
+        name: 'fields',
+        type: 'bytes1',
+        internalType: 'bytes1',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'version',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'chainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'verifyingContract',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'salt',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'extensions',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
     ],
     stateMutability: 'view',
   },
@@ -135,65 +313,141 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'getChainID',
     inputs: [],
-    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getDestToken',
     inputs: [
-      { name: 'orderToken', type: 'address', internalType: 'address' },
-      { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'orderToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
     outputs: [
-      { name: 'adChainToken', type: 'address', internalType: 'address' },
+      {
+        name: 'adChainToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getHistoricalRoot',
-    inputs: [{ name: 'index', type: 'uint256', internalType: 'uint256' }],
-    outputs: [{ name: 'root', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'index',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'root',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getLatestMerkleRoot',
     inputs: [],
-    outputs: [{ name: 'root', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'root',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getMerkleLeafCount',
     inputs: [],
-    outputs: [{ name: 'count', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      {
+        name: 'count',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getRoleAdmin',
-    inputs: [{ name: 'role', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'getSigner',
     inputs: [
-      { name: 'message', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
     stateMutability: 'pure',
   },
   {
     type: 'function',
     name: 'grantRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -202,22 +456,58 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'hasRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'hashRequest',
     inputs: [
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
-      { name: '_action', type: 'string', internalType: 'string' },
-      { name: '_params', type: 'bytes[]', internalType: 'bytes[]' },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_action',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: '_params',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
     ],
-    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
@@ -225,7 +515,11 @@ export const ORDER_PORTAL_ABI = [
     name: 'i_merkleManager',
     inputs: [],
     outputs: [
-      { name: '', type: 'address', internalType: 'contract IMerkleManager' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract IMerkleManager',
+      },
     ],
     stateMutability: 'view',
   },
@@ -234,37 +528,81 @@ export const ORDER_PORTAL_ABI = [
     name: 'i_verifier',
     inputs: [],
     outputs: [
-      { name: '', type: 'address', internalType: 'contract IVerifier' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract IVerifier',
+      },
     ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'managers',
-    inputs: [{ name: '', type: 'address', internalType: 'address' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'nullifierUsed',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'orders',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     outputs: [
-      { name: '', type: 'uint8', internalType: 'enum OrderPortal.Status' },
+      {
+        name: '',
+        type: 'uint8',
+        internalType: 'enum OrderPortal.Status',
+      },
     ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'removeChain',
-    inputs: [{ name: 'adChainId', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
     outputs: [],
     stateMutability: 'nonpayable',
   },
@@ -272,8 +610,16 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'removeTokenRoute',
     inputs: [
-      { name: 'orderToken', type: 'address', internalType: 'address' },
-      { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'orderToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -282,8 +628,16 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'renounceRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'callerConfirmation', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'callerConfirmation',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -291,23 +645,55 @@ export const ORDER_PORTAL_ABI = [
   {
     type: 'function',
     name: 'requestHashes',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'requestTokens',
-    inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'revokeRole',
     inputs: [
-      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -316,9 +702,21 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'setChain',
     inputs: [
-      { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'adManager', type: 'address', internalType: 'address' },
-      { name: 'supported', type: 'bool', internalType: 'bool' },
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adManager',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'supported',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -327,8 +725,16 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'setManager',
     inputs: [
-      { name: '_manager', type: 'address', internalType: 'address' },
-      { name: '_status', type: 'bool', internalType: 'bool' },
+      {
+        name: '_manager',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_status',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -337,9 +743,21 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'setTokenRoute',
     inputs: [
-      { name: 'orderToken', type: 'address', internalType: 'address' },
-      { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
-      { name: 'adToken', type: 'address', internalType: 'address' },
+      {
+        name: 'orderToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'adToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -347,48 +765,142 @@ export const ORDER_PORTAL_ABI = [
   {
     type: 'function',
     name: 'supportsInterface',
-    inputs: [{ name: 'interfaceId', type: 'bytes4', internalType: 'bytes4' }],
-    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    inputs: [
+      {
+        name: 'interfaceId',
+        type: 'bytes4',
+        internalType: 'bytes4',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'tokenRoute',
     inputs: [
-      { name: '', type: 'address', internalType: 'address' },
-      { name: '', type: 'uint256', internalType: 'uint256' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
     type: 'function',
     name: 'unlock',
     inputs: [
-      { name: 'signature', type: 'bytes', internalType: 'bytes' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
       {
         name: 'params',
         type: 'tuple',
         internalType: 'struct OrderPortal.OrderParams',
         components: [
-          { name: 'orderChainToken', type: 'address', internalType: 'address' },
-          { name: 'adChainToken', type: 'address', internalType: 'address' },
-          { name: 'amount', type: 'uint256', internalType: 'uint256' },
-          { name: 'bridger', type: 'address', internalType: 'address' },
-          { name: 'orderRecipient', type: 'address', internalType: 'address' },
-          { name: 'adChainId', type: 'uint256', internalType: 'uint256' },
-          { name: 'adManager', type: 'address', internalType: 'address' },
-          { name: 'adId', type: 'string', internalType: 'string' },
-          { name: 'adCreator', type: 'address', internalType: 'address' },
-          { name: 'adRecipient', type: 'address', internalType: 'address' },
-          { name: 'salt', type: 'uint256', internalType: 'uint256' },
+          {
+            name: 'orderChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adChainToken',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'bridger',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'orderRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adChainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'adManager',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adId',
+            type: 'string',
+            internalType: 'string',
+          },
+          {
+            name: 'adCreator',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'adRecipient',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'salt',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
         ],
       },
-      { name: 'nullifierHash', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'targetRoot', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'proof', type: 'bytes', internalType: 'bytes' },
+      {
+        name: 'nullifierHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'targetRoot',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'proof',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
     outputs: [],
     stateMutability: 'payable',
@@ -397,13 +909,39 @@ export const ORDER_PORTAL_ABI = [
     type: 'function',
     name: 'unlockOrderRequestHash',
     inputs: [
-      { name: 'adId', type: 'string', internalType: 'string' },
-      { name: 'orderHash', type: 'bytes32', internalType: 'bytes32' },
-      { name: '_targetRoot', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'authToken', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'timeToExpire', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'adId',
+        type: 'string',
+        internalType: 'string',
+      },
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: '_targetRoot',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'authToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: 'timeToExpire',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    outputs: [{ name: 'message', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     stateMutability: 'view',
   },
   {
@@ -411,7 +949,11 @@ export const ORDER_PORTAL_ABI = [
     name: 'wNativeToken',
     inputs: [],
     outputs: [
-      { name: '', type: 'address', internalType: 'contract IwNativeToken' },
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract IwNativeToken',
+      },
     ],
     stateMutability: 'view',
   },
@@ -427,15 +969,25 @@ export const ORDER_PORTAL_ABI = [
       },
       {
         name: 'adManager',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
-      { name: 'supported', type: 'bool', indexed: false, internalType: 'bool' },
+      {
+        name: 'supported',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
     ],
     anonymous: false,
   },
-  { type: 'event', name: 'EIP712DomainChanged', inputs: [], anonymous: false },
+  {
+    type: 'event',
+    name: 'EIP712DomainChanged',
+    inputs: [],
+    anonymous: false,
+  },
   {
     type: 'event',
     name: 'OrderCreated',
@@ -448,15 +1000,15 @@ export const ORDER_PORTAL_ABI = [
       },
       {
         name: 'bridger',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'orderChainToken',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'amount',
@@ -472,28 +1024,33 @@ export const ORDER_PORTAL_ABI = [
       },
       {
         name: 'adChainToken',
-        type: 'address',
+        type: 'bytes32',
         indexed: false,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'adManager',
-        type: 'address',
+        type: 'bytes32',
         indexed: false,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
-      { name: 'adId', type: 'string', indexed: false, internalType: 'string' },
+      {
+        name: 'adId',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
       {
         name: 'adCreator',
-        type: 'address',
+        type: 'bytes32',
         indexed: false,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'adRecipient',
-        type: 'address',
+        type: 'bytes32',
         indexed: false,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
     ],
     anonymous: false,
@@ -510,9 +1067,9 @@ export const ORDER_PORTAL_ABI = [
       },
       {
         name: 'recipient',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
       {
         name: 'nullifierHash',
@@ -527,7 +1084,12 @@ export const ORDER_PORTAL_ABI = [
     type: 'event',
     name: 'RoleAdminChanged',
     inputs: [
-      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
       {
         name: 'previousAdminRole',
         type: 'bytes32',
@@ -547,7 +1109,12 @@ export const ORDER_PORTAL_ABI = [
     type: 'event',
     name: 'RoleGranted',
     inputs: [
-      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
       {
         name: 'account',
         type: 'address',
@@ -567,7 +1134,12 @@ export const ORDER_PORTAL_ABI = [
     type: 'event',
     name: 'RoleRevoked',
     inputs: [
-      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      {
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
       {
         name: 'account',
         type: 'address',
@@ -620,9 +1192,9 @@ export const ORDER_PORTAL_ABI = [
       },
       {
         name: 'adChainToken',
-        type: 'address',
+        type: 'bytes32',
         indexed: true,
-        internalType: 'address',
+        internalType: 'bytes32',
       },
     ],
     anonymous: false,
@@ -637,90 +1209,250 @@ export const ORDER_PORTAL_ABI = [
         indexed: true,
         internalType: 'address',
       },
-      { name: 'status', type: 'bool', indexed: false, internalType: 'bool' },
+      {
+        name: 'status',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
     ],
     anonymous: false,
   },
-  { type: 'error', name: 'AccessControlBadConfirmation', inputs: [] },
+  {
+    type: 'error',
+    name: 'AccessControlBadConfirmation',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'AccessControlUnauthorizedAccount',
     inputs: [
-      { name: 'account', type: 'address', internalType: 'address' },
-      { name: 'neededRole', type: 'bytes32', internalType: 'bytes32' },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'neededRole',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
-  { type: 'error', name: 'ECDSAInvalidSignature', inputs: [] },
+  {
+    type: 'error',
+    name: 'ECDSAInvalidSignature',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'ECDSAInvalidSignatureLength',
-    inputs: [{ name: 'length', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: 'length',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'ECDSAInvalidSignatureS',
-    inputs: [{ name: 's', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 's',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
-  { type: 'error', name: 'InvalidShortString', inputs: [] },
+  {
+    type: 'error',
+    name: 'InvalidShortString',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'OrderPortal__AdChainNotSupported',
-    inputs: [{ name: 'adChainId', type: 'uint256', internalType: 'uint256' }],
+    inputs: [
+      {
+        name: 'adChainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'OrderPortal__AdManagerMismatch',
-    inputs: [{ name: 'expected', type: 'address', internalType: 'address' }],
+    inputs: [
+      {
+        name: 'expected',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
-  { type: 'error', name: 'OrderPortal__AdTokenMismatch', inputs: [] },
-  { type: 'error', name: 'OrderPortal__BridgerMustBeSender', inputs: [] },
-  { type: 'error', name: 'OrderPortal__InsufficientLiquidity', inputs: [] },
-  { type: 'error', name: 'OrderPortal__InvalidAdRecipient', inputs: [] },
-  { type: 'error', name: 'OrderPortal__InvalidMessage', inputs: [] },
-  { type: 'error', name: 'OrderPortal__InvalidProof', inputs: [] },
-  { type: 'error', name: 'OrderPortal__InvalidSigner', inputs: [] },
-  { type: 'error', name: 'OrderPortal__MerkleManagerAppendFailed', inputs: [] },
-  { type: 'error', name: 'OrderPortal__MissingRoute', inputs: [] },
+  {
+    type: 'error',
+    name: 'OrderPortal__AdTokenMismatch',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__BridgerMustBeSender',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__InsufficientLiquidity',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__InvalidAdRecipient',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__InvalidMessage',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__InvalidProof',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__InvalidSigner',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__MerkleManagerAppendFailed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__MissingRoute',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__NotEvmAddress',
+    inputs: [
+      {
+        name: 'value',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+  },
   {
     type: 'error',
     name: 'OrderPortal__NullifierUsed',
     inputs: [
-      { name: 'nullifierHash', type: 'bytes32', internalType: 'bytes32' },
+      {
+        name: 'nullifierHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
   {
     type: 'error',
     name: 'OrderPortal__OrderExists',
-    inputs: [{ name: 'orderHash', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'OrderPortal__OrderNotOpen',
-    inputs: [{ name: 'orderHash', type: 'bytes32', internalType: 'bytes32' }],
+    inputs: [
+      {
+        name: 'orderHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
-  { type: 'error', name: 'OrderPortal__RequestHashedProcessed', inputs: [] },
-  { type: 'error', name: 'OrderPortal__RequestTokenExpired', inputs: [] },
+  {
+    type: 'error',
+    name: 'OrderPortal__RequestHashedProcessed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__RequestTokenExpired',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'OrderPortal__RoutesZeroAddress',
     inputs: [
-      { name: 'orderToken', type: 'address', internalType: 'address' },
-      { name: 'adToken', type: 'address', internalType: 'address' },
+      {
+        name: 'orderToken',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'adToken',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
   },
-  { type: 'error', name: 'OrderPortal__TokenAlreadyUsed', inputs: [] },
-  { type: 'error', name: 'OrderPortal__ZeroAddress', inputs: [] },
-  { type: 'error', name: 'OrderPortal__ZeroAmount', inputs: [] },
-  { type: 'error', name: 'OrderPortal__ZeroSigner', inputs: [] },
-  { type: 'error', name: 'ReentrancyGuardReentrantCall', inputs: [] },
+  {
+    type: 'error',
+    name: 'OrderPortal__TokenAlreadyUsed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__ZeroAddress',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__ZeroAmount',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OrderPortal__ZeroSigner',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ReentrancyGuardReentrantCall',
+    inputs: [],
+  },
   {
     type: 'error',
     name: 'SafeERC20FailedOperation',
-    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
   },
   {
     type: 'error',
     name: 'StringTooLong',
-    inputs: [{ name: 'str', type: 'string', internalType: 'string' }],
+    inputs: [
+      {
+        name: 'str',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
   },
-];
+] as const;

--- a/apps/backend-relayer/src/providers/viem/ethers/typedData.ts
+++ b/apps/backend-relayer/src/providers/viem/ethers/typedData.ts
@@ -1,9 +1,20 @@
 import { TypedDataEncoder, Wallet, recoverAddress } from 'ethers';
 import {
+  Bytes32Hex,
   T_AdManagerOrderParams,
   T_OrderParams,
   T_OrderPortalParams,
 } from '../types';
+
+// Left-pad a 20-byte EVM address to 32 bytes (the cross-chain wire format).
+// Accepts an already-32-byte hex string and returns it unchanged. Throws on
+// malformed input.
+export function toBytes32(value: string): Bytes32Hex {
+  const hex = value.replace(/^0x/i, '').toLowerCase();
+  if (hex.length === 64) return `0x${hex}`;
+  if (hex.length === 40) return `0x${'0'.repeat(24)}${hex}`;
+  throw new Error(`toBytes32: expected 20- or 32-byte hex, got ${value}`);
+}
 
 // ----------------------------
 // OrderPortal typed data
@@ -17,20 +28,24 @@ export const domain = {
 // ----------------------------
 // OrderPortal typed data
 // ----------------------------
+// All address-like fields are bytes32 for cross-chain parity (Stellar
+// addresses are 32 bytes; EVM addresses are left-padded with 12 zero bytes).
+// Must match the on-chain ORDER_TYPEHASH in OrderPortal.sol / AdManager.sol
+// and proofbridge-core/src/eip712.rs.
 export const orderTypes: Record<string, { name: string; type: string }[]> = {
   Order: [
-    { name: 'orderChainToken', type: 'address' },
-    { name: 'adChainToken', type: 'address' },
+    { name: 'orderChainToken', type: 'bytes32' },
+    { name: 'adChainToken', type: 'bytes32' },
     { name: 'amount', type: 'uint256' },
-    { name: 'bridger', type: 'address' },
+    { name: 'bridger', type: 'bytes32' },
     { name: 'orderChainId', type: 'uint256' },
-    { name: 'orderPortal', type: 'address' },
-    { name: 'orderRecipient', type: 'address' },
+    { name: 'orderPortal', type: 'bytes32' },
+    { name: 'orderRecipient', type: 'bytes32' },
     { name: 'adChainId', type: 'uint256' },
-    { name: 'adManager', type: 'address' },
+    { name: 'adManager', type: 'bytes32' },
     { name: 'adId', type: 'string' },
-    { name: 'adCreator', type: 'address' },
-    { name: 'adRecipient', type: 'address' },
+    { name: 'adCreator', type: 'bytes32' },
+    { name: 'adRecipient', type: 'bytes32' },
     { name: 'salt', type: 'uint256' },
   ],
 };

--- a/apps/backend-relayer/src/providers/viem/types.ts
+++ b/apps/backend-relayer/src/providers/viem/types.ts
@@ -1,11 +1,24 @@
+// Cross-chain bytes32 convention
+// ────────────────────────────────────────────────────────────────────
+// All address-like fields that cross chain boundaries are `Bytes32Hex`
+// (0x-prefixed, 64 hex chars). For EVM addresses this means left-padded
+// with 12 zero bytes; for Stellar addresses the full 32-byte strkey payload.
+//
+// Fields that stay on the ad chain itself (the AdManager contract address,
+// the ad's local ERC20 `adToken`, withdraw `to`) remain 20-byte EVM
+// addresses because they're only ever consumed by EVM ABI calls.
+
+export type Bytes32Hex = `0x${string}`;
+export type EvmAddress = `0x${string}`;
+
 export type T_CreateAdRequest = {
-  adContractAddress: `0x${string}`;
+  adContractAddress: EvmAddress;
   adChainId: bigint;
   adId: string;
-  adToken: `0x${string}`;
+  adToken: EvmAddress;
   initialAmount: string;
   orderChainId: bigint;
-  adRecipient: `0x${string}`;
+  adRecipient: Bytes32Hex;
 };
 
 export type T_CreateAdRequestContractDetails = {
@@ -15,15 +28,15 @@ export type T_CreateAdRequestContractDetails = {
   authToken: string;
   timeToExpire: number;
   adId: string;
-  adToken: `0x${string}`;
+  adToken: EvmAddress;
   initialAmount: string;
   orderChainId: string;
-  adRecipient: `0x${string}`;
+  adRecipient: Bytes32Hex;
   reqHash: `0x${string}`;
 };
 
 export type T_CreatFundAdRequest = {
-  adContractAddress: `0x${string}`;
+  adContractAddress: EvmAddress;
   adChainId: bigint;
   adId: string;
   amount: string;
@@ -41,11 +54,11 @@ export type T_CreatFundAdRequestContractDetails = {
 };
 
 export type T_WithdrawFromAdRequest = {
-  adContractAddress: `0x${string}`;
+  adContractAddress: EvmAddress;
   adChainId: bigint;
   adId: string;
   amount: string;
-  to: `0x${string}`;
+  to: EvmAddress;
 };
 
 export type T_WithdrawFromAdRequestContractDetails = {
@@ -56,15 +69,15 @@ export type T_WithdrawFromAdRequestContractDetails = {
   timeToExpire: number;
   adId: string;
   amount: string;
-  to: `0x${string}`;
+  to: EvmAddress;
   reqHash: `0x${string}`;
 };
 
 export type T_CloseAdRequest = {
-  adContractAddress: `0x${string}`;
+  adContractAddress: EvmAddress;
   adChainId: bigint;
   adId: string;
-  to: `0x${string}`;
+  to: EvmAddress;
 };
 
 export type T_CloseAdRequestContractDetails = {
@@ -74,56 +87,64 @@ export type T_CloseAdRequestContractDetails = {
   authToken: string;
   timeToExpire: number;
   adId: string;
-  to: `0x${string}`;
+  to: EvmAddress;
   reqHash: `0x${string}`;
 };
 
+// Canonical cross-chain order — matches the EIP-712 `Order` typehash in
+// OrderPortal.sol and AdManager.sol. All addresses are bytes32.
 export type T_OrderParams = {
-  orderChainToken: string;
-  adChainToken: string;
+  orderChainToken: Bytes32Hex;
+  adChainToken: Bytes32Hex;
   amount: string;
-  bridger: string;
+  bridger: Bytes32Hex;
   orderChainId: string;
-  orderPortal: string;
-  orderRecipient: string;
+  orderPortal: Bytes32Hex;
+  orderRecipient: Bytes32Hex;
   adChainId: string;
-  adManager: string;
+  adManager: Bytes32Hex;
   adId: string;
-  adCreator: string;
-  adRecipient: string;
+  adCreator: Bytes32Hex;
+  adRecipient: Bytes32Hex;
   salt: string;
 };
 
+// Ad-chain subset passed to AdManager.lockForOrder / unlock. The local
+// AdManager address + adChainId are implicit from the call site so they're
+// not in the struct; `srcOrderPortal` is the remote OrderPortal bytes32.
 export type T_AdManagerOrderParams = {
-  orderChainToken: string;
-  adChainToken: string;
+  orderChainToken: Bytes32Hex;
+  adChainToken: Bytes32Hex;
   amount: string;
-  bridger: string;
+  bridger: Bytes32Hex;
   orderChainId: string;
-  srcOrderPortal: string;
-  orderRecipient: string;
+  srcOrderPortal: Bytes32Hex;
+  orderRecipient: Bytes32Hex;
   adId: string;
-  adCreator: string;
-  adRecipient: string;
+  adCreator: Bytes32Hex;
+  adRecipient: Bytes32Hex;
   salt: string;
 };
 
+// Order-chain subset passed to OrderPortal.createOrder / unlock. The local
+// OrderPortal address + orderChainId are implicit.
 export type T_OrderPortalParams = {
-  orderChainToken: string;
-  adChainToken: string;
+  orderChainToken: Bytes32Hex;
+  adChainToken: Bytes32Hex;
   amount: string;
-  bridger: string;
-  orderRecipient: string;
+  bridger: Bytes32Hex;
+  orderRecipient: Bytes32Hex;
   adChainId: string;
-  adManager: string;
+  adManager: Bytes32Hex;
   adId: string;
-  adCreator: string;
-  adRecipient: string;
+  adCreator: Bytes32Hex;
+  adRecipient: Bytes32Hex;
   salt: string;
 };
 
 export type T_LockForOrderRequest = {
   adChainId: bigint;
+  adContractAddress: EvmAddress;
   orderParams: T_OrderParams;
 };
 
@@ -140,12 +161,13 @@ export type T_LockForOrderRequestContractDetails = {
 
 export type T_CreateOrderRequest = {
   orderChainId: bigint;
+  orderContractAddress: EvmAddress;
   orderParams: T_OrderParams;
 };
 
 export type T_CreateUnlockOrderContractDetails = {
   chainId: bigint;
-  contractAddress: `0x${string}`;
+  contractAddress: EvmAddress;
   isAdCreator: boolean;
   orderParams: T_OrderParams;
   nullifierHash: string;
@@ -155,7 +177,7 @@ export type T_CreateUnlockOrderContractDetails = {
 
 export type T_UnlockOrderContractDetails = {
   chainId: string;
-  contractAddress: `0x${string}`;
+  contractAddress: EvmAddress;
   signature: `0x${string}`;
   authToken: string;
   timeToExpire: number;
@@ -180,13 +202,13 @@ export type T_CreateOrderRequestContractDetails = {
 
 export type T_RequestValidation = {
   chainId: bigint;
-  contractAddress: `0x${string}`;
+  contractAddress: EvmAddress;
   reqHash: `0x${string}`;
 };
 
 export type T_FetchRoot = {
   chainId: bigint;
-  contractAddress: `0x${string}`;
+  contractAddress: EvmAddress;
 };
 
 export type T_FetchRootResponse = {

--- a/apps/backend-relayer/src/providers/viem/viem.service.ts
+++ b/apps/backend-relayer/src/providers/viem/viem.service.ts
@@ -285,7 +285,7 @@ export class ViemService {
   async getLockForOrderRequestContractDetails(
     data: T_LockForOrderRequest,
   ): Promise<T_LockForOrderRequestContractDetails> {
-    const { adChainId, orderParams } = data;
+    const { adChainId, adContractAddress, orderParams } = data;
     const { client, wallet } = this.getClient(adChainId.toString());
     const token: `0x${string}` = keccak256(toHex(randomUUID()));
 
@@ -299,7 +299,7 @@ export class ViemService {
     const orderHash = getTypedHash(data.orderParams);
 
     const message = await client.readContract({
-      address: orderParams.adManager,
+      address: adContractAddress,
       abi: AD_MANAGER_ABI,
       functionName: 'lockForOrderRequestHash',
       args: [orderParams.adId, orderHash, token, timeToExpire],
@@ -316,7 +316,7 @@ export class ViemService {
 
     return {
       chainId: adChainId.toString(),
-      contractAddress: orderParams.adManager,
+      contractAddress: adContractAddress,
       signature,
       authToken: token,
       timeToExpire: Number(timeToExpire),
@@ -329,7 +329,7 @@ export class ViemService {
   async getCreateOrderRequestContractDetails(
     data: T_CreateOrderRequest,
   ): Promise<T_CreateOrderRequestContractDetails> {
-    const { orderChainId, orderParams } = data;
+    const { orderChainId, orderContractAddress, orderParams } = data;
     const { client, wallet } = this.getClient(orderChainId.toString());
     const token: `0x${string}` = keccak256(toHex(randomUUID()));
 
@@ -343,7 +343,7 @@ export class ViemService {
     const orderHash = getTypedHash(data.orderParams);
 
     const message = await client.readContract({
-      address: orderParams.orderPortal,
+      address: orderContractAddress,
       abi: ORDER_PORTAL_ABI,
       functionName: 'createOrderRequestHash',
       args: [orderParams.adId, orderHash, token, timeToExpire],
@@ -357,7 +357,7 @@ export class ViemService {
 
     return {
       chainId: orderChainId.toString(),
-      contractAddress: orderParams.orderPortal,
+      contractAddress: orderContractAddress,
       signature,
       authToken: token,
       timeToExpire: Number(timeToExpire),

--- a/apps/backend-relayer/test/integrations/eth-hedera-e2e-integration.ts
+++ b/apps/backend-relayer/test/integrations/eth-hedera-e2e-integration.ts
@@ -151,7 +151,7 @@ describe('Integrations E2E — (ETH → Hedera)', () => {
       ethClient,
       account1,
       req.signature,
-      req.authToken,
+      req.authToken as `0x${string}`,
       req.timeToExpire,
       req.adId,
       req.adToken,
@@ -328,7 +328,7 @@ describe('Integrations E2E — (ETH → Hedera)', () => {
       ethClient,
       account1,
       req.signature,
-      req.authToken,
+      req.authToken as `0x${string}`,
       req.timeToExpire,
       req.adId,
       req.adToken,
@@ -422,9 +422,9 @@ describe('Integrations E2E — (ETH → Hedera)', () => {
       hederaClient,
       account2,
       orderReq.signature,
-      orderReq.authToken,
+      orderReq.authToken as `0x${string}`,
       orderReq.timeToExpire,
-      orderReq.orderParams,
+      orderReq.orderParams as T_OrderPortalParams,
       hederaChain.orderPortalAddress,
     );
 
@@ -458,10 +458,10 @@ describe('Integrations E2E — (ETH → Hedera)', () => {
     const lockTxn = await lockForOrder(
       ethClient,
       account1,
-      lockOrderReq.signature,
-      lockOrderReq.authToken,
+      lockOrderReq.signature as `0x${string}`,
+      lockOrderReq.authToken as `0x${string}`,
       lockOrderReq.timeToExpire,
-      lockOrderReq.orderParams,
+      lockOrderReq.orderParams as T_AdManagerOrderParams,
       getAddress(lockOrderReq.contractAddress),
     );
 
@@ -504,12 +504,12 @@ describe('Integrations E2E — (ETH → Hedera)', () => {
       hederaClient,
       account1,
       unlockReq.signature,
-      unlockReq.authToken,
+      unlockReq.authToken as `0x${string}`,
       unlockReq.timeToExpire,
       unlockReq.orderParams as T_OrderPortalParams,
-      unlockReq.nullifierHash,
-      unlockReq.targetRoot,
-      unlockReq.proof,
+      unlockReq.nullifierHash as `0x${string}`,
+      unlockReq.targetRoot as `0x${string}`,
+      unlockReq.proof as `0x${string}`,
       unlockReq.contractAddress,
     );
 
@@ -563,12 +563,12 @@ describe('Integrations E2E — (ETH → Hedera)', () => {
       ethClient,
       account1,
       unlockReqBridger.signature,
-      unlockReqBridger.authToken,
+      unlockReqBridger.authToken as `0x${string}`,
       unlockReqBridger.timeToExpire,
       unlockReqBridger.orderParams as T_AdManagerOrderParams,
-      unlockReqBridger.nullifierHash,
-      unlockReqBridger.targetRoot,
-      unlockReqBridger.proof,
+      unlockReqBridger.nullifierHash as `0x${string}`,
+      unlockReqBridger.targetRoot as `0x${string}`,
+      unlockReqBridger.proof as `0x${string}`,
       unlockReqBridger.contractAddress,
     );
 

--- a/apps/backend-relayer/test/setups/contract-actions.ts
+++ b/apps/backend-relayer/test/setups/contract-actions.ts
@@ -2,7 +2,7 @@ import { AD_MANAGER_ABI } from '../../src/providers/viem/abis/adManager.abi';
 import { ORDER_PORTAL_ABI } from '../../src/providers/viem/abis/orderPortal.abi';
 import { MERKLE_MANAGER_ABI } from '../../src/providers/viem/abis/merkleManager.abi';
 
-import Erc20MockArtifact from '../../../contracts/out/ERC20Mock.sol/ERC20Mock.json';
+import Erc20MockArtifact from '../../../../contracts/evm/out/ERC20Mock.sol/ERC20Mock.json';
 
 import { ethers } from 'ethers';
 import { ChainData, AddressLike } from './utils';
@@ -18,7 +18,7 @@ import {
   PublicClient,
 } from 'viem';
 
-const DEFAULT_ADMIN_ROLE = ethers.ZeroHash;
+const DEFAULT_ADMIN_ROLE = ethers.ZeroHash as `0x${string}`;
 
 export async function grantManagerRole(
   publicClient: PublicClient,
@@ -220,14 +220,14 @@ export async function adminSetup(
 export async function createAd(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   adId: string,
-  adToken: string,
+  adToken: `0x${string}`,
   fundAmount: string,
   orderChainId: string,
-  adRecipient: string,
+  adRecipient: `0x${string}`,
   adManagerAddress: string,
 ) {
   console.log(adManagerAddress);
@@ -269,8 +269,8 @@ export async function createAd(
 export async function fundAd(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   adId: string,
   amount: bigint,
@@ -304,12 +304,12 @@ export async function fundAd(
 export async function withdrawAdFunds(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   adId: string,
   amount: bigint,
-  to: string,
+  to: `0x${string}`,
   adManagerAddress: string,
 ) {
   const wallet = createWalletClient({
@@ -323,7 +323,7 @@ export async function withdrawAdFunds(
     address: adManagerAddress as AddressLike,
     abi: AD_MANAGER_ABI,
     functionName: 'withdrawFromAd',
-    args: [signature, authToken, timeToExpire, adId, amount, to],
+    args: [signature, authToken, BigInt(timeToExpire), adId, amount, to],
   });
 
   const receipt = await publicClient.waitForTransactionReceipt({ hash });
@@ -340,11 +340,11 @@ export async function withdrawAdFunds(
 export async function closeAd(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   adId: string,
-  to: string,
+  to: `0x${string}`,
   adManagerAddress: string,
 ) {
   const wallet = createWalletClient({
@@ -358,7 +358,7 @@ export async function closeAd(
     address: adManagerAddress as AddressLike,
     abi: AD_MANAGER_ABI,
     functionName: 'closeAd',
-    args: [signature, authToken, timeToExpire, adId, to],
+    args: [signature, authToken, BigInt(timeToExpire), adId, to],
   });
 
   const receipt = await publicClient.waitForTransactionReceipt({ hash });
@@ -375,8 +375,8 @@ export async function closeAd(
 export async function createOrder(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   orderParams: T_OrderPortalParams,
   orderPortalAddress: string,
@@ -395,7 +395,7 @@ export async function createOrder(
     args: [
       signature,
       authToken,
-      timeToExpire,
+      BigInt(timeToExpire),
       {
         ...orderParams,
         amount: BigInt(orderParams.amount),
@@ -419,8 +419,8 @@ export async function createOrder(
 export async function lockForOrder(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   orderParams: T_AdManagerOrderParams,
   adManagerAddress: AddressLike,
@@ -445,18 +445,18 @@ export async function lockForOrder(
     args: [
       signature,
       authToken,
-      timeToExpire,
+      BigInt(timeToExpire),
       {
-        orderChainToken: getAddress(orderParams.orderChainToken),
-        adChainToken: getAddress(orderParams.adChainToken),
+        orderChainToken: orderParams.orderChainToken,
+        adChainToken: orderParams.adChainToken,
         amount: BigInt(orderParams.amount),
-        bridger: getAddress(orderParams.bridger),
+        bridger: orderParams.bridger,
         orderChainId: BigInt(orderParams.orderChainId),
-        srcOrderPortal: getAddress(orderParams.srcOrderPortal),
-        orderRecipient: getAddress(orderParams.orderRecipient),
+        srcOrderPortal: orderParams.srcOrderPortal,
+        orderRecipient: orderParams.orderRecipient,
         adId: orderParams.adId,
-        adCreator: getAddress(orderParams.adCreator),
-        adRecipient: getAddress(orderParams.adRecipient),
+        adCreator: orderParams.adCreator,
+        adRecipient: orderParams.adRecipient,
         salt: BigInt(orderParams.salt),
       },
     ],
@@ -476,13 +476,13 @@ export async function lockForOrder(
 export async function unlockAdChain(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   orderParams: T_AdManagerOrderParams,
-  nullifierHash: string,
-  targetRoot: string,
-  proof: string,
+  nullifierHash: `0x${string}`,
+  targetRoot: `0x${string}`,
+  proof: `0x${string}`,
   adManagerAddress: string,
 ) {
   const wallet = createWalletClient({
@@ -499,13 +499,12 @@ export async function unlockAdChain(
     args: [
       signature,
       authToken,
-      timeToExpire,
+      BigInt(timeToExpire),
       {
         ...orderParams,
         amount: BigInt(orderParams.amount),
         orderChainId: BigInt(orderParams.orderChainId),
         salt: BigInt(orderParams.salt),
-        srcOrderPortal: getAddress(orderParams.srcOrderPortal),
       },
       nullifierHash,
       targetRoot,
@@ -527,13 +526,13 @@ export async function unlockAdChain(
 export async function unlockOrderChain(
   publicClient: PublicClient,
   account: PrivateKeyAccount,
-  signature: string,
-  authToken: string,
+  signature: `0x${string}`,
+  authToken: `0x${string}`,
   timeToExpire: number,
   orderParams: T_OrderPortalParams,
-  nullifierHash: string,
-  targetRoot: string,
-  proof: string,
+  nullifierHash: `0x${string}`,
+  targetRoot: `0x${string}`,
+  proof: `0x${string}`,
   orderPortalAddress: string,
 ) {
   const wallet = createWalletClient({
@@ -551,7 +550,7 @@ export async function unlockOrderChain(
     args: [
       signature,
       authToken,
-      timeToExpire,
+      BigInt(timeToExpire),
       {
         ...orderParams,
         amount: BigInt(orderParams.amount),

--- a/apps/backend-relayer/test/setups/contract-setup.ts
+++ b/apps/backend-relayer/test/setups/contract-setup.ts
@@ -3,11 +3,11 @@ import path from 'path';
 import dotenv from 'dotenv';
 import { hederaTestnet as hederaLocalnet } from 'viem/chains';
 
-import MerkleManagerArtifact from '../../../contracts/out/MerkleManager.sol/MerkleManager.json';
-import VerifierArtifact from '../../../contracts/out/Verifier.sol/HonkVerifier.json';
-import AdManagerArtifact from '../../../contracts/out/AdManager.sol/AdManager.json';
-import OrderPortalArtifact from '../../../contracts/out/OrderPortal.sol/OrderPortal.json';
-import Erc20MockArtifact from '../../../contracts/out/ERC20Mock.sol/ERC20Mock.json';
+import MerkleManagerArtifact from '../../../../contracts/evm/out/MerkleManager.sol/MerkleManager.json';
+import VerifierArtifact from '../../../../contracts/evm/out/Verifier.sol/HonkVerifier.json';
+import AdManagerArtifact from '../../../../contracts/evm/out/AdManager.sol/AdManager.json';
+import OrderPortalArtifact from '../../../../contracts/evm/out/OrderPortal.sol/OrderPortal.json';
+import Erc20MockArtifact from '../../../../contracts/evm/out/ERC20Mock.sol/ERC20Mock.json';
 
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { ethLocalnet } from '../../src/providers/viem/localnet';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: 1.0.0-beta.9
         version: 1.0.0-beta.9
       '@prisma/client':
-        specifier: 7.7.0
-        version: 7.7.0(prisma@6.16.1(typescript@5.9.3))(typescript@5.9.3)
+        specifier: 6.16.1
+        version: 6.16.1(prisma@6.16.1(typescript@5.9.3))(typescript@5.9.3)
       '@types/morgan':
         specifier: ^1.9.10
         version: 1.9.10
@@ -2005,15 +2005,12 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@prisma/client-runtime-utils@7.7.0':
-    resolution: {integrity: sha512-BLyd0UpFYOtyJFTHm7jS9vesHW7P83abibodQMiIofqjBKzDHQ1VAsQkdfvXyYDkPlONPfOTz7/rv3x/+CQqvQ==}
-
-  '@prisma/client@7.7.0':
-    resolution: {integrity: sha512-5Ar4OsZpJ54s21sy5oDNNW9gQtd4NuxCaiM7+JDTOU07D6VvlpLjYzAVCMB1+JzokN+08dAVomlx+b7bhJd3ww==}
-    engines: {node: ^20.19 || ^22.12 || >=24.0}
+  '@prisma/client@6.16.1':
+    resolution: {integrity: sha512-QaBCOY29lLAxEFFJgBPyW3WInCW52fJeQTmWx/h6YsP5u0bwuqP51aP0uhqFvhK9DaZPwvai/M4tSDYLVE9vRg==}
+    engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
-      typescript: '>=5.4.0'
+      typescript: '>=5.1.0'
     peerDependenciesMeta:
       prisma:
         optional: true
@@ -5332,10 +5329,6 @@ packages:
     peerDependenciesMeta:
       node-notifier:
         optional: true
-
-  jiti@2.5.1:
-    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
-    hasBin: true
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -9631,11 +9624,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@prisma/client-runtime-utils@7.7.0': {}
-
-  '@prisma/client@7.7.0(prisma@6.16.1(typescript@5.9.3))(typescript@5.9.3)':
-    dependencies:
-      '@prisma/client-runtime-utils': 7.7.0
+  '@prisma/client@6.16.1(prisma@6.16.1(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.16.1(typescript@5.9.3)
       typescript: 5.9.3
@@ -12310,7 +12299,7 @@ snapshots:
       dotenv: 16.6.1
       exsolve: 1.0.7
       giget: 2.0.0
-      jiti: 2.5.1
+      jiti: 2.6.1
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 1.0.0
@@ -12983,8 +12972,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -13010,7 +12999,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -13021,21 +13010,21 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13046,7 +13035,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14327,8 +14316,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jiti@2.5.1: {}
 
   jiti@2.6.1: {}
 

--- a/scripts/cross-chain-e2e/lib/evm.ts
+++ b/scripts/cross-chain-e2e/lib/evm.ts
@@ -178,12 +178,3 @@ export function getContract(
   const { abi } = loadArtifact(contractFileName, contractName);
   return new ethers.Contract(address, abi, signer);
 }
-
-/** Create a signer for EVM interactions. */
-export function createSigner(
-  rpcUrl: string,
-  privateKey: string,
-): ethers.Wallet {
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
-  return new ethers.Wallet(privateKey, provider);
-}

--- a/scripts/cross-chain-e2e/lib/signing.ts
+++ b/scripts/cross-chain-e2e/lib/signing.ts
@@ -8,7 +8,6 @@
 import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha512";
 import { ethers, keccak256 } from "ethers";
-import { randomBytes } from "crypto";
 
 // noble/ed25519 v2 needs sha512 configured
 ed.etc.sha512Sync = (...m: Uint8Array[]) => {
@@ -128,16 +127,6 @@ export function unlockOrderRequestHash(
 
 // ── ed25519 signing ─────────────────────────────────────────────────
 
-/** Generate an ed25519 keypair. Returns { publicKey (32), secretKey (32) }. */
-export function generateEd25519Keypair(): {
-  publicKey: Buffer;
-  secretKey: Buffer;
-} {
-  const secretKey = Buffer.from(randomBytes(32));
-  const publicKey = Buffer.from(ed.getPublicKey(secretKey));
-  return { publicKey, secretKey };
-}
-
 /** Sign a 32-byte message hash with ed25519. Returns 64-byte signature. */
 export function signEd25519(message: Buffer, secretKey: Buffer): Buffer {
   const sig = ed.sign(message, secretKey);
@@ -155,12 +144,6 @@ export class AuthTokenCounter {
     const buf = Buffer.alloc(32, 0);
     buf.writeUInt32BE(this.counter, 28);
     return buf;
-  }
-
-  /** Return as bytes32 hex string for EVM calls. */
-  nextHex(): string {
-    this.counter++;
-    return "0x" + this.counter.toString(16).padStart(64, "0");
   }
 }
 

--- a/scripts/cross-chain-e2e/lib/stellar.ts
+++ b/scripts/cross-chain-e2e/lib/stellar.ts
@@ -63,24 +63,6 @@ export function getAddress(name: string = SOURCE): string {
 }
 
 /**
- * Idempotently generate a Stellar key under `name` and fund it via friendbot.
- * Safe to call repeatedly — existing keys / accounts are left alone.
- */
-export function generateAndFundKey(name: string): string {
-  try {
-    stellar(`keys generate "${name}"`);
-  } catch {
-    // Already exists — leave it alone.
-  }
-  try {
-    stellar(`keys fund "${name}" --network "${NETWORK}"`);
-  } catch {
-    // Already funded — fine.
-  }
-  return getAddress(name);
-}
-
-/**
  * Deploy a Stellar Asset Contract (SAC) for a classic asset, returning its
  * C... contract ID. If the SAC is already deployed, falls back to looking up
  * the id via `contract id asset`. Use `--asset native` for XLM.
@@ -106,24 +88,6 @@ export function getSecret(name: string = SOURCE): string {
 
 const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
-function base32Encode(data: Uint8Array): string {
-  let bits = 0;
-  let value = 0;
-  let result = "";
-  for (const byte of data) {
-    value = (value << 8) | byte;
-    bits += 8;
-    while (bits >= 5) {
-      result += BASE32_ALPHABET[(value >>> (bits - 5)) & 0x1f];
-      bits -= 5;
-    }
-  }
-  if (bits > 0) {
-    result += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f];
-  }
-  return result;
-}
-
 export function base32Decode(str: string): Uint8Array {
   const lookup: Record<string, number> = {};
   for (let i = 0; i < BASE32_ALPHABET.length; i++) {
@@ -143,57 +107,12 @@ export function base32Decode(str: string): Uint8Array {
   return new Uint8Array(bytes);
 }
 
-function crc16xmodem(data: Uint8Array): number {
-  let crc = 0x0000;
-  for (const byte of data) {
-    crc ^= byte << 8;
-    for (let i = 0; i < 8; i++) {
-      if (crc & 0x8000) {
-        crc = ((crc << 1) ^ 0x1021) & 0xffff;
-      } else {
-        crc = (crc << 1) & 0xffff;
-      }
-    }
-  }
-  return crc;
-}
-
-const STRKEY_ED25519 = 6 << 3; // 48 → G prefix
-const STRKEY_CONTRACT = 2 << 3; // 16 → C prefix
-
-function encodeStrkey(versionByte: number, payload: Buffer): string {
-  const body = Buffer.concat([Buffer.from([versionByte]), payload]);
-  const checksum = crc16xmodem(body);
-  const full = Buffer.concat([
-    body,
-    Buffer.from([checksum & 0xff, (checksum >> 8) & 0xff]),
-  ]);
-  return base32Encode(full);
-}
-
 /** Decode a Stellar strkey address (C.../G...) to 32-byte hex. */
 export function strkeyToHex(strkey: string): string {
   const decoded = base32Decode(strkey);
   // Skip version byte (1), take 32 bytes, skip checksum (2)
   const payload = decoded.slice(1, 33);
   return "0x" + Buffer.from(payload).toString("hex");
-}
-
-/** Encode 32-byte hex as C... (contract) address. */
-export function hexToContractAddress(hex: string): string {
-  const buf = Buffer.from(hex.replace(/^0x/i, ""), "hex");
-  return encodeStrkey(STRKEY_CONTRACT, buf);
-}
-
-/** Encode 32-byte hex as G... (account) address. */
-export function hexToAccountAddress(hex: string): string {
-  const buf = Buffer.from(hex.replace(/^0x/i, ""), "hex");
-  return encodeStrkey(STRKEY_ED25519, buf);
-}
-
-/** Convert an ed25519 public key (32-byte Buffer) to a Stellar G... address. */
-export function pubkeyToAddress(pubkey: Buffer): string {
-  return encodeStrkey(STRKEY_ED25519, pubkey);
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated address handling in cross-chain operations to use bytes32 format instead of 20-byte addresses
  * Updated contract ABI definitions and type definitions to support the new address format
  * Removed unused utility helper functions
  * Aligned Prisma ORM client version with existing constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->