### PR TITLE
  fix(contracts): validate recipient addresses in order validation

### DIFF
--- a/apps/frontend/abis/AdManager.abi.ts
+++ b/apps/frontend/abis/AdManager.abi.ts
@@ -1,1918 +1,1140 @@
 export const AD_MANAGER_ABI = [
   {
-    "type": "constructor",
-    "inputs": [
+    type: "constructor",
+    inputs: [
+      { name: "admin", type: "address", internalType: "address" },
       {
-        "name": "admin",
-        "type": "address",
-        "internalType": "address"
+        name: "_verifier",
+        type: "address",
+        internalType: "contract IVerifier",
       },
       {
-        "name": "_verifier",
-        "type": "address",
-        "internalType": "contract IVerifier"
+        name: "_merkleManager",
+        type: "address",
+        internalType: "contract IMerkleManager",
       },
       {
-        "name": "_merkleManager",
-        "type": "address",
-        "internalType": "contract IMerkleManager"
+        name: "_wNativeToken",
+        type: "address",
+        internalType: "contract IwNativeToken",
       },
-      {
-        "name": "_wNativeToken",
-        "type": "address",
-        "internalType": "contract IwNativeToken"
-      }
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: "nonpayable",
+  },
+  { type: "fallback", stateMutability: "payable" },
+  { type: "receive", stateMutability: "payable" },
+  {
+    type: "function",
+    name: "ADMIN_ROLE",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "fallback",
-    "stateMutability": "payable"
+    type: "function",
+    name: "DEFAULT_ADMIN_ROLE",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "receive",
-    "stateMutability": "payable"
+    type: "function",
+    name: "adIds",
+    inputs: [{ name: "", type: "string", internalType: "string" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "ADMIN_ROLE",
-    "inputs": [],
-    "outputs": [
+    type: "function",
+    name: "ads",
+    inputs: [{ name: "", type: "string", internalType: "string" }],
+    outputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "orderChainId",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      { name: "adRecipient", type: "bytes32", internalType: "bytes32" },
+      { name: "maker", type: "address", internalType: "address" },
+      { name: "token", type: "address", internalType: "address" },
+      { name: "balance", type: "uint256", internalType: "uint256" },
+      { name: "locked", type: "uint256", internalType: "uint256" },
+      { name: "open", type: "bool", internalType: "bool" },
     ],
-    "stateMutability": "view"
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "DEFAULT_ADMIN_ROLE",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
+    type: "function",
+    name: "availableLiquidity",
+    inputs: [{ name: "adId", type: "string", internalType: "string" }],
+    outputs: [{ name: "amount", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "adIds",
-    "inputs": [
-      {
-        "name": "",
-        "type": "string",
-        "internalType": "string"
-      }
+    type: "function",
+    name: "chains",
+    inputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    outputs: [
+      { name: "supported", type: "bool", internalType: "bool" },
+      { name: "orderPortal", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "ads",
-    "inputs": [
-      {
-        "name": "",
-        "type": "string",
-        "internalType": "string"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adRecipient",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "maker",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "balance",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "locked",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "open",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
+    type: "function",
+    name: "checkRequestHashExists",
+    inputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "availableLiquidity",
-    "inputs": [
+    type: "function",
+    name: "closeAd",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
       {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "to", type: "address", internalType: "address" },
     ],
-    "outputs": [
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
+    outputs: [],
+    stateMutability: "nonpayable",
   },
   {
-    "type": "function",
-    "name": "chains",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+    type: "function",
+    name: "closeAdRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [
-      {
-        "name": "supported",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "orderPortal",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "checkRequestHashExists",
-    "inputs": [
+    type: "function",
+    name: "createAd",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
       {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "adToken", type: "address", internalType: "address" },
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "initialAmount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "orderChainId",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      { name: "adRecipient", type: "bytes32", internalType: "bytes32" },
     ],
-    "stateMutability": "view"
+    outputs: [],
+    stateMutability: "payable",
   },
   {
-    "type": "function",
-    "name": "closeAd",
-    "inputs": [
+    type: "function",
+    name: "createAdRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "adToken", type: "address", internalType: "address" },
       {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: "initialAmount",
+        type: "uint256",
+        internalType: "uint256",
       },
       {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        name: "orderChainId",
+        type: "uint256",
+        internalType: "uint256",
       },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      }
+      { name: "adRecipient", type: "bytes32", internalType: "bytes32" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "closeAdRequestHash",
-    "inputs": [
+    type: "function",
+    name: "fundAd",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
       {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
       },
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
+    outputs: [],
+    stateMutability: "payable",
   },
   {
-    "type": "function",
-    "name": "createAd",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "adToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "initialAmount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adRecipient",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+    type: "function",
+    name: "fundAdRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "createAdRequestHash",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "adToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "initialAmount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adRecipient",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
+    type: "function",
+    name: "getHistoricalRoot",
+    inputs: [{ name: "index", type: "uint256", internalType: "uint256" }],
+    outputs: [{ name: "root", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "fundAd",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "payable"
+    type: "function",
+    name: "getLatestMerkleRoot",
+    inputs: [],
+    outputs: [{ name: "root", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "fundAdRequestHash",
-    "inputs": [
+    type: "function",
+    name: "getMerkleLeafCount",
+    inputs: [],
+    outputs: [{ name: "count", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getRoleAdmin",
+    inputs: [{ name: "role", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "grantRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "hasRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
+    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "i_merkleManager",
+    inputs: [],
+    outputs: [
       {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
+        name: "",
+        type: "address",
+        internalType: "contract IMerkleManager",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "i_verifier",
+    inputs: [],
+    outputs: [
+      { name: "", type: "address", internalType: "contract IVerifier" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "lockForOrder",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      {
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getHistoricalRoot",
-    "inputs": [
-      {
-        "name": "index",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getLatestMerkleRoot",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getMerkleLeafCount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "count",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRoleAdmin",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "grantRole",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "hasRole",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "i_merkleManager",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IMerkleManager"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "i_verifier",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IVerifier"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "lockForOrder",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "params",
-        "type": "tuple",
-        "internalType": "struct AdManager.OrderParams",
-        "components": [
+        name: "params",
+        type: "tuple",
+        internalType: "struct AdManager.OrderParams",
+        components: [
           {
-            "name": "orderChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "orderChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "amount", type: "uint256", internalType: "uint256" },
+          { name: "bridger", type: "bytes32", internalType: "bytes32" },
+          {
+            name: "orderChainId",
+            type: "uint256",
+            internalType: "uint256",
           },
           {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: "srcOrderPortal",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "bridger",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "orderRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "adId", type: "string", internalType: "string" },
+          {
+            name: "adCreator",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "orderChainId",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: "adRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "salt", type: "uint256", internalType: "uint256" },
+          {
+            name: "orderDecimals",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          { name: "adDecimals", type: "uint8", internalType: "uint8" },
+        ],
+      },
+    ],
+    outputs: [{ name: "orderHash", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "lockForOrderRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "orderHash", type: "bytes32", internalType: "bytes32" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "managers",
+    inputs: [{ name: "", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "nullifierUsed",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "orders",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [
+      { name: "", type: "uint8", internalType: "enum AdManager.Status" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "removeChain",
+    inputs: [
+      { name: "orderChainId", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "removeTokenRoute",
+    inputs: [
+      { name: "adToken", type: "address", internalType: "address" },
+      { name: "orderChainId", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "renounceRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      {
+        name: "callerConfirmation",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "requestHashes",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "requestTokens",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "revokeRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setChain",
+    inputs: [
+      {
+        name: "orderChainId",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      { name: "orderPortal", type: "bytes32", internalType: "bytes32" },
+      { name: "supported", type: "bool", internalType: "bool" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setManager",
+    inputs: [
+      { name: "_manager", type: "address", internalType: "address" },
+      { name: "_status", type: "bool", internalType: "bool" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setTokenRoute",
+    inputs: [
+      { name: "adToken", type: "address", internalType: "address" },
+      { name: "orderToken", type: "bytes32", internalType: "bytes32" },
+      { name: "orderChainId", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [{ name: "interfaceId", type: "bytes4", internalType: "bytes4" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "tokenRoute",
+    inputs: [
+      { name: "", type: "address", internalType: "address" },
+      { name: "", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "unlock",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      {
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "params",
+        type: "tuple",
+        internalType: "struct AdManager.OrderParams",
+        components: [
+          {
+            name: "orderChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "srcOrderPortal",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "amount", type: "uint256", internalType: "uint256" },
+          { name: "bridger", type: "bytes32", internalType: "bytes32" },
+          {
+            name: "orderChainId",
+            type: "uint256",
+            internalType: "uint256",
           },
           {
-            "name": "orderRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "srcOrderPortal",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adId",
-            "type": "string",
-            "internalType": "string"
+            name: "orderRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "adId", type: "string", internalType: "string" },
+          {
+            name: "adCreator",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adCreator",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
           },
+          { name: "salt", type: "uint256", internalType: "uint256" },
           {
-            "name": "adRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "orderDecimals",
+            type: "uint8",
+            internalType: "uint8",
           },
-          {
-            "name": "salt",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "orderDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "adDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          }
-        ]
-      }
+          { name: "adDecimals", type: "uint8", internalType: "uint8" },
+        ],
+      },
+      {
+        name: "nullifierHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      { name: "targetRoot", type: "bytes32", internalType: "bytes32" },
+      { name: "proof", type: "bytes", internalType: "bytes" },
     ],
-    "outputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "unlockOrderRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "orderHash", type: "bytes32", internalType: "bytes32" },
+      { name: "_targetRoot", type: "bytes32", internalType: "bytes32" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
     ],
-    "stateMutability": "nonpayable"
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
   },
   {
-    "type": "function",
-    "name": "lockForOrderRequestHash",
-    "inputs": [
+    type: "function",
+    name: "wNativeToken",
+    inputs: [],
+    outputs: [
       {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
+        name: "",
+        type: "address",
+        internalType: "contract IwNativeToken",
       },
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
     ],
-    "outputs": [
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "withdrawFromAd",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
       {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+      { name: "to", type: "address", internalType: "address" },
     ],
-    "stateMutability": "view"
+    outputs: [],
+    stateMutability: "nonpayable",
   },
   {
-    "type": "function",
-    "name": "managers",
-    "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+    type: "function",
+    name: "withdrawFromAdRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "AdClosed",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "adId",
+        type: "string",
+        indexed: true,
+        internalType: "string",
+      },
+      {
+        name: "maker",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "nullifierUsed",
-    "inputs": [
+    type: "event",
+    name: "AdCreated",
+    inputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "adId",
+        type: "string",
+        indexed: true,
+        internalType: "string",
+      },
+      {
+        name: "maker",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "token",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "initAmount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "orderChainId",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "AdFunded",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "adId",
+        type: "string",
+        indexed: true,
+        internalType: "string",
+      },
+      {
+        name: "maker",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "newBalance",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "orders",
-    "inputs": [
+    type: "event",
+    name: "AdWithdrawn",
+    inputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "adId",
+        type: "string",
+        indexed: true,
+        internalType: "string",
+      },
+      {
+        name: "maker",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "newBalance",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ChainSet",
+    inputs: [
       {
-        "name": "",
-        "type": "uint8",
-        "internalType": "enum AdManager.Status"
-      }
+        name: "chainId",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "orderPortal",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "supported",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "removeChain",
-    "inputs": [
+    type: "event",
+    name: "OrderLocked",
+    inputs: [
       {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: "adId",
+        type: "string",
+        indexed: true,
+        internalType: "string",
+      },
+      {
+        name: "orderHash",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "maker",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      {
+        name: "token",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "bridger",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
+      {
+        name: "recipient",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "removeTokenRoute",
-    "inputs": [
+    type: "event",
+    name: "OrderUnlocked",
+    inputs: [
       {
-        "name": "adToken",
-        "type": "address",
-        "internalType": "address"
+        name: "orderHash",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
       },
       {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: "recipient",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "nullifierHash",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "renounceRole",
-    "inputs": [
+    type: "event",
+    name: "RoleAdminChanged",
+    inputs: [
       {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        name: "role",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
       },
       {
-        "name": "callerConfirmation",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: "previousAdminRole",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "newAdminRole",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "requestHashes",
-    "inputs": [
+    type: "event",
+    name: "RoleGranted",
+    inputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "role",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "sender",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "RoleRevoked",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "role",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "sender",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "requestTokens",
-    "inputs": [
+    type: "event",
+    name: "TokenRouteRemoved",
+    inputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "adToken",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "orderChainToken",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "orderChainId",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "TokenRouteSet",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "adToken",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "orderChainId",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "orderChainToken",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "revokeRole",
-    "inputs": [
+    type: "event",
+    name: "UpdateManager",
+    inputs: [
       {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        name: "manager",
+        type: "address",
+        indexed: true,
+        internalType: "address",
       },
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: "status",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    anonymous: false,
   },
+  { type: "error", name: "AccessControlBadConfirmation", inputs: [] },
   {
-    "type": "function",
-    "name": "setChain",
-    "inputs": [
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "orderPortal",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "supported",
-        "type": "bool",
-        "internalType": "bool"
-      }
+    type: "error",
+    name: "AccessControlUnauthorizedAccount",
+    inputs: [
+      { name: "account", type: "address", internalType: "address" },
+      { name: "neededRole", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
+  { type: "error", name: "AdManager__AdClosed", inputs: [] },
+  { type: "error", name: "AdManager__AdNotFound", inputs: [] },
   {
-    "type": "function",
-    "name": "setManager",
-    "inputs": [
-      {
-        "name": "_manager",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "_status",
-        "type": "bool",
-        "internalType": "bool"
-      }
+    type: "error",
+    name: "AdManager__AdRecipientMismatch",
+    inputs: [
+      { name: "expected", type: "bytes32", internalType: "bytes32" },
+      { name: "provided", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
   {
-    "type": "function",
-    "name": "setTokenRoute",
-    "inputs": [
-      {
-        "name": "adToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "orderToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+    type: "error",
+    name: "AdManager__AdTokenMismatch",
+    inputs: [
+      { name: "expected", type: "bytes32", internalType: "bytes32" },
+      { name: "provided", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+  },
+  { type: "error", name: "AdManager__BridgerZero", inputs: [] },
+  {
+    type: "error",
+    name: "AdManager__ChainNotSupported",
+    inputs: [{ name: "chainId", type: "uint256", internalType: "uint256" }],
   },
   {
-    "type": "function",
-    "name": "supportsInterface",
-    "inputs": [
+    type: "error",
+    name: "AdManager__InsufficientLiquidity",
+    inputs: [],
+  },
+  { type: "error", name: "AdManager__InvalidProof", inputs: [] },
+  {
+    type: "error",
+    name: "AdManager__MerkleManagerAppendFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "AdManager__MissingRoute",
+    inputs: [
       {
-        "name": "interfaceId",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
+        name: "orderChainToken",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      { name: "adChainId", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [
+  },
+  { type: "error", name: "AdManager__NotMaker", inputs: [] },
+  {
+    type: "error",
+    name: "AdManager__NullifierUsed",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "nullifierHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
     ],
-    "stateMutability": "view"
   },
   {
-    "type": "function",
-    "name": "tokenRoute",
-    "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+    type: "error",
+    name: "AdManager__OrderChainMismatch",
+    inputs: [
+      { name: "expected", type: "uint256", internalType: "uint256" },
+      { name: "provided", type: "uint256", internalType: "uint256" },
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+  },
+  {
+    type: "error",
+    name: "AdManager__OrderExists",
+    inputs: [{ name: "orderHash", type: "bytes32", internalType: "bytes32" }],
+  },
+  {
+    type: "error",
+    name: "AdManager__OrderNotOpen",
+    inputs: [{ name: "orderHash", type: "bytes32", internalType: "bytes32" }],
+  },
+  {
+    type: "error",
+    name: "AdManager__OrderPortalMismatch",
+    inputs: [
+      { name: "expected", type: "bytes32", internalType: "bytes32" },
+      { name: "provided", type: "bytes32", internalType: "bytes32" },
     ],
-    "stateMutability": "view"
   },
   {
-    "type": "function",
-    "name": "unlock",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "params",
-        "type": "tuple",
-        "internalType": "struct AdManager.OrderParams",
-        "components": [
-          {
-            "name": "orderChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "bridger",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "orderChainId",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "srcOrderPortal",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "orderRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adId",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "adCreator",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "salt",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "orderDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "adDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          }
-        ]
-      },
-      {
-        "name": "nullifierHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "targetRoot",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "proof",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+    type: "error",
+    name: "AdManager__OrderTokenMismatch",
+    inputs: [
+      { name: "expected", type: "bytes32", internalType: "bytes32" },
+      { name: "provided", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+  },
+  { type: "error", name: "AdManager__RecipientZero", inputs: [] },
+  { type: "error", name: "AdManager__TokenAlreadyUsed", inputs: [] },
+  { type: "error", name: "AdManager__TokenZeroAddress", inputs: [] },
+  { type: "error", name: "AdManager__UsedAdId", inputs: [] },
+  { type: "error", name: "AdManager__ZeroAddress", inputs: [] },
+  { type: "error", name: "AdManager__ZeroAmount", inputs: [] },
+  {
+    type: "error",
+    name: "AddressCast__NotEvmAddress",
+    inputs: [{ name: "value", type: "bytes32", internalType: "bytes32" }],
+  },
+  { type: "error", name: "Admanager__ActiveLocks", inputs: [] },
+  { type: "error", name: "Admanager__InvalidSigner", inputs: [] },
+  {
+    type: "error",
+    name: "Admanager__RequestHashedProcessed",
+    inputs: [],
   },
   {
-    "type": "function",
-    "name": "unlockOrderRequestHash",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "_targetRoot",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+    type: "error",
+    name: "DecimalScaling__DecimalsMismatch",
+    inputs: [
+      { name: "expected", type: "uint8", internalType: "uint8" },
+      { name: "provided", type: "uint8", internalType: "uint8" },
     ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+  },
+  {
+    type: "error",
+    name: "DecimalScaling__DecimalsOutOfRange",
+    inputs: [{ name: "value", type: "uint8", internalType: "uint8" }],
+  },
+  {
+    type: "error",
+    name: "DecimalScaling__DecimalsUnavailable",
+    inputs: [{ name: "token", type: "address", internalType: "address" }],
+  },
+  {
+    type: "error",
+    name: "DecimalScaling__NonExactDownscale",
+    inputs: [
+      { name: "amount", type: "uint256", internalType: "uint256" },
+      { name: "fromDec", type: "uint8", internalType: "uint8" },
+      { name: "toDec", type: "uint8", internalType: "uint8" },
     ],
-    "stateMutability": "view"
+  },
+  { type: "error", name: "ECDSAInvalidSignature", inputs: [] },
+  {
+    type: "error",
+    name: "ECDSAInvalidSignatureLength",
+    inputs: [{ name: "length", type: "uint256", internalType: "uint256" }],
   },
   {
-    "type": "function",
-    "name": "wNativeToken",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IwNativeToken"
-      }
-    ],
-    "stateMutability": "view"
+    type: "error",
+    name: "ECDSAInvalidSignatureS",
+    inputs: [{ name: "s", type: "bytes32", internalType: "bytes32" }],
   },
+  { type: "error", name: "ReentrancyGuardReentrantCall", inputs: [] },
+  { type: "error", name: "RequestAuth__Expired", inputs: [] },
+  { type: "error", name: "RequestAuth__InvalidMessage", inputs: [] },
+  { type: "error", name: "RequestAuth__ZeroSigner", inputs: [] },
   {
-    "type": "function",
-    "name": "withdrawFromAd",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [{ name: "token", type: "address", internalType: "address" }],
   },
-  {
-    "type": "function",
-    "name": "withdrawFromAdRequestHash",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "event",
-    "name": "AdClosed",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "indexed": true,
-        "internalType": "string"
-      },
-      {
-        "name": "maker",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "AdCreated",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "indexed": true,
-        "internalType": "string"
-      },
-      {
-        "name": "maker",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "initAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "AdFunded",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "indexed": true,
-        "internalType": "string"
-      },
-      {
-        "name": "maker",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "newBalance",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "AdWithdrawn",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "indexed": true,
-        "internalType": "string"
-      },
-      {
-        "name": "maker",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "newBalance",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ChainSet",
-    "inputs": [
-      {
-        "name": "chainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "orderPortal",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "supported",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OrderLocked",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "indexed": true,
-        "internalType": "string"
-      },
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "maker",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "token",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "bridger",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "recipient",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OrderUnlocked",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "recipient",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "nullifierHash",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RoleAdminChanged",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "previousAdminRole",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "newAdminRole",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RoleGranted",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RoleRevoked",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TokenRouteRemoved",
-    "inputs": [
-      {
-        "name": "adToken",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "orderChainToken",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TokenRouteSet",
-    "inputs": [
-      {
-        "name": "adToken",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "orderChainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "orderChainToken",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "UpdateManager",
-    "inputs": [
-      {
-        "name": "manager",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "status",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "error",
-    "name": "AccessControlBadConfirmation",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AccessControlUnauthorizedAccount",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "neededRole",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__AdClosed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__AdNotFound",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__AdRecipientMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "provided",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__AdTokenMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "provided",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__BridgerZero",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__ChainNotSupported",
-    "inputs": [
-      {
-        "name": "chainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__InsufficientLiquidity",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__InvalidProof",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__MerkleManagerAppendFailed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__MissingRoute",
-    "inputs": [
-      {
-        "name": "orderChainToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__NotMaker",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__NullifierUsed",
-    "inputs": [
-      {
-        "name": "nullifierHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__OrderChainMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "provided",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__OrderExists",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__OrderNotOpen",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__OrderPortalMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "provided",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__OrderTokenMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "provided",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AdManager__RecipientZero",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__TokenAlreadyUsed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__TokenZeroAddress",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__UsedAdId",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__ZeroAddress",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AdManager__ZeroAmount",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AddressCast__NotEvmAddress",
-    "inputs": [
-      {
-        "name": "value",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "Admanager__ActiveLocks",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "Admanager__InvalidSigner",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "Admanager__RequestHashedProcessed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "DecimalScaling__DecimalsMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "uint8",
-        "internalType": "uint8"
-      },
-      {
-        "name": "provided",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "DecimalScaling__DecimalsOutOfRange",
-    "inputs": [
-      {
-        "name": "value",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "DecimalScaling__NonExactDownscale",
-    "inputs": [
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "fromDec",
-        "type": "uint8",
-        "internalType": "uint8"
-      },
-      {
-        "name": "toDec",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignature",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureS",
-    "inputs": [
-      {
-        "name": "s",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ReentrancyGuardReentrantCall",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RequestAuth__Expired",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RequestAuth__InvalidMessage",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RequestAuth__ZeroSigner",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SafeERC20FailedOperation",
-    "inputs": [
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  }
-]
- as const;
+];

--- a/apps/frontend/abis/orderPortal.abi.ts
+++ b/apps/frontend/abis/orderPortal.abi.ts
@@ -1,1326 +1,822 @@
 export const ORDER_PORTAL_ABI = [
   {
-    "type": "constructor",
-    "inputs": [
+    type: "constructor",
+    inputs: [
+      { name: "admin", type: "address", internalType: "address" },
       {
-        "name": "admin",
-        "type": "address",
-        "internalType": "address"
+        name: "_verifier",
+        type: "address",
+        internalType: "contract IVerifier",
       },
       {
-        "name": "_verifier",
-        "type": "address",
-        "internalType": "contract IVerifier"
+        name: "_merkleManager",
+        type: "address",
+        internalType: "contract IMerkleManager",
       },
       {
-        "name": "_merkleManager",
-        "type": "address",
-        "internalType": "contract IMerkleManager"
+        name: "_wNativeToken",
+        type: "address",
+        internalType: "contract IwNativeToken",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  { type: "fallback", stateMutability: "payable" },
+  { type: "receive", stateMutability: "payable" },
+  {
+    type: "function",
+    name: "ADMIN_ROLE",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "DEFAULT_ADMIN_ROLE",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "chains",
+    inputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    outputs: [
+      { name: "supported", type: "bool", internalType: "bool" },
+      { name: "adManager", type: "bytes32", internalType: "bytes32" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "checkRequestHashExists",
+    inputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "createOrder",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      {
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
       },
       {
-        "name": "_wNativeToken",
-        "type": "address",
-        "internalType": "contract IwNativeToken"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "fallback",
-    "stateMutability": "payable"
-  },
-  {
-    "type": "receive",
-    "stateMutability": "payable"
-  },
-  {
-    "type": "function",
-    "name": "ADMIN_ROLE",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "DEFAULT_ADMIN_ROLE",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "chains",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "supported",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "adManager",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "checkRequestHashExists",
-    "inputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "createOrder",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "params",
-        "type": "tuple",
-        "internalType": "struct OrderPortal.OrderParams",
-        "components": [
+        name: "params",
+        type: "tuple",
+        internalType: "struct OrderPortal.OrderParams",
+        components: [
           {
-            "name": "orderChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "orderChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "amount", type: "uint256", internalType: "uint256" },
+          { name: "bridger", type: "bytes32", internalType: "bytes32" },
+          {
+            name: "orderRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: "adChainId",
+            type: "uint256",
+            internalType: "uint256",
           },
           {
-            "name": "bridger",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adManager",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "adId", type: "string", internalType: "string" },
+          {
+            name: "adCreator",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "orderRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "salt", type: "uint256", internalType: "uint256" },
+          {
+            name: "orderDecimals",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          { name: "adDecimals", type: "uint8", internalType: "uint8" },
+        ],
+      },
+    ],
+    outputs: [{ name: "orderHash", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "createOrderRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "orderHash", type: "bytes32", internalType: "bytes32" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getDestToken",
+    inputs: [
+      { name: "orderToken", type: "address", internalType: "address" },
+      { name: "adChainId", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [
+      { name: "adChainToken", type: "bytes32", internalType: "bytes32" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getHistoricalRoot",
+    inputs: [{ name: "index", type: "uint256", internalType: "uint256" }],
+    outputs: [{ name: "root", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getLatestMerkleRoot",
+    inputs: [],
+    outputs: [{ name: "root", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getMerkleLeafCount",
+    inputs: [],
+    outputs: [{ name: "count", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getRoleAdmin",
+    inputs: [{ name: "role", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "grantRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "hasRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
+    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "i_merkleManager",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IMerkleManager",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "i_verifier",
+    inputs: [],
+    outputs: [
+      { name: "", type: "address", internalType: "contract IVerifier" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "managers",
+    inputs: [{ name: "", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "nullifierUsed",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "orders",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [
+      {
+        name: "",
+        type: "uint8",
+        internalType: "enum OrderPortal.Status",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "removeChain",
+    inputs: [{ name: "adChainId", type: "uint256", internalType: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "removeTokenRoute",
+    inputs: [
+      { name: "orderToken", type: "address", internalType: "address" },
+      { name: "adChainId", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "renounceRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      {
+        name: "callerConfirmation",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "requestHashes",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "requestTokens",
+    inputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "revokeRole",
+    inputs: [
+      { name: "role", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setChain",
+    inputs: [
+      { name: "adChainId", type: "uint256", internalType: "uint256" },
+      { name: "adManager", type: "bytes32", internalType: "bytes32" },
+      { name: "supported", type: "bool", internalType: "bool" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setManager",
+    inputs: [
+      { name: "_manager", type: "address", internalType: "address" },
+      { name: "_status", type: "bool", internalType: "bool" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setTokenRoute",
+    inputs: [
+      { name: "orderToken", type: "address", internalType: "address" },
+      { name: "adChainId", type: "uint256", internalType: "uint256" },
+      { name: "adToken", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [{ name: "interfaceId", type: "bytes4", internalType: "bytes4" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "tokenRoute",
+    inputs: [
+      { name: "", type: "address", internalType: "address" },
+      { name: "", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "unlock",
+    inputs: [
+      { name: "signature", type: "bytes", internalType: "bytes" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      {
+        name: "timeToExpire",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "params",
+        type: "tuple",
+        internalType: "struct OrderPortal.OrderParams",
+        components: [
+          {
+            name: "orderChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adChainId",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: "adChainToken",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "amount", type: "uint256", internalType: "uint256" },
+          { name: "bridger", type: "bytes32", internalType: "bytes32" },
+          {
+            name: "orderRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adManager",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adChainId",
+            type: "uint256",
+            internalType: "uint256",
           },
           {
-            "name": "adId",
-            "type": "string",
-            "internalType": "string"
+            name: "adManager",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          { name: "adId", type: "string", internalType: "string" },
+          {
+            name: "adCreator",
+            type: "bytes32",
+            internalType: "bytes32",
           },
           {
-            "name": "adCreator",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "adRecipient",
+            type: "bytes32",
+            internalType: "bytes32",
           },
+          { name: "salt", type: "uint256", internalType: "uint256" },
           {
-            "name": "adRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: "orderDecimals",
+            type: "uint8",
+            internalType: "uint8",
           },
-          {
-            "name": "salt",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "orderDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "adDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          }
-        ]
-      }
-    ],
-    "outputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "payable"
-  },
-  {
-    "type": "function",
-    "name": "createOrderRequestHash",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
+          { name: "adDecimals", type: "uint8", internalType: "uint8" },
+        ],
       },
       {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        name: "nullifierHash",
+        type: "bytes32",
+        internalType: "bytes32",
       },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { name: "targetRoot", type: "bytes32", internalType: "bytes32" },
+      { name: "proof", type: "bytes", internalType: "bytes" },
     ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
+    outputs: [],
+    stateMutability: "nonpayable",
   },
   {
-    "type": "function",
-    "name": "getDestToken",
-    "inputs": [
+    type: "function",
+    name: "unlockOrderRequestHash",
+    inputs: [
+      { name: "adId", type: "string", internalType: "string" },
+      { name: "orderHash", type: "bytes32", internalType: "bytes32" },
+      { name: "_targetRoot", type: "bytes32", internalType: "bytes32" },
+      { name: "authToken", type: "bytes32", internalType: "bytes32" },
+      { name: "timeToExpire", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [{ name: "message", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "wNativeToken",
+    inputs: [],
+    outputs: [
       {
-        "name": "orderToken",
-        "type": "address",
-        "internalType": "address"
+        name: "",
+        type: "address",
+        internalType: "contract IwNativeToken",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "ChainSet",
+    inputs: [
+      {
+        name: "chainId",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
       },
       {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "adChainToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getHistoricalRoot",
-    "inputs": [
-      {
-        "name": "index",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getLatestMerkleRoot",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getMerkleLeafCount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "count",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRoleAdmin",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "grantRole",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        name: "adManager",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
       },
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: "supported",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "hasRole",
-    "inputs": [
+    type: "event",
+    name: "OrderCreated",
+    inputs: [
       {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        name: "orderHash",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
       },
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: "bridger",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "orderChainToken",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "adChainId",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "adChainToken",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
+      {
+        name: "adManager",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
+      {
+        name: "adId",
+        type: "string",
+        indexed: false,
+        internalType: "string",
+      },
+      {
+        name: "adCreator",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
+      {
+        name: "adRecipient",
+        type: "bytes32",
+        indexed: false,
+        internalType: "bytes32",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OrderUnlocked",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "orderHash",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "recipient",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "nullifierHash",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "i_merkleManager",
-    "inputs": [],
-    "outputs": [
+    type: "event",
+    name: "RoleAdminChanged",
+    inputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IMerkleManager"
-      }
+        name: "role",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "previousAdminRole",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "newAdminRole",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "i_verifier",
-    "inputs": [],
-    "outputs": [
+    type: "event",
+    name: "RoleGranted",
+    inputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IVerifier"
-      }
+        name: "role",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "sender",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "managers",
-    "inputs": [
+    type: "event",
+    name: "RoleRevoked",
+    inputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: "role",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "sender",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "TokenRouteRemoved",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "orderChainToken",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "adChainId",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
   {
-    "type": "function",
-    "name": "nullifierUsed",
-    "inputs": [
+    type: "event",
+    name: "TokenRouteSet",
+    inputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: "orderChainToken",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "adChainId",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "adChainToken",
+        type: "bytes32",
+        indexed: true,
+        internalType: "bytes32",
+      },
     ],
-    "outputs": [
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "UpdateManager",
+    inputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: "manager",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "status",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
     ],
-    "stateMutability": "view"
+    anonymous: false,
   },
+  { type: "error", name: "AccessControlBadConfirmation", inputs: [] },
   {
-    "type": "function",
-    "name": "orders",
-    "inputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+    type: "error",
+    name: "AccessControlUnauthorizedAccount",
+    inputs: [
+      { name: "account", type: "address", internalType: "address" },
+      { name: "neededRole", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint8",
-        "internalType": "enum OrderPortal.Status"
-      }
+  },
+  {
+    type: "error",
+    name: "AddressCast__NotEvmAddress",
+    inputs: [{ name: "value", type: "bytes32", internalType: "bytes32" }],
+  },
+  {
+    type: "error",
+    name: "DecimalScaling__DecimalsMismatch",
+    inputs: [
+      { name: "expected", type: "uint8", internalType: "uint8" },
+      { name: "provided", type: "uint8", internalType: "uint8" },
     ],
-    "stateMutability": "view"
   },
   {
-    "type": "function",
-    "name": "removeChain",
-    "inputs": [
+    type: "error",
+    name: "DecimalScaling__DecimalsOutOfRange",
+    inputs: [{ name: "value", type: "uint8", internalType: "uint8" }],
+  },
+  {
+    type: "error",
+    name: "DecimalScaling__DecimalsUnavailable",
+    inputs: [{ name: "token", type: "address", internalType: "address" }],
+  },
+  { type: "error", name: "ECDSAInvalidSignature", inputs: [] },
+  {
+    type: "error",
+    name: "ECDSAInvalidSignatureLength",
+    inputs: [{ name: "length", type: "uint256", internalType: "uint256" }],
+  },
+  {
+    type: "error",
+    name: "ECDSAInvalidSignatureS",
+    inputs: [{ name: "s", type: "bytes32", internalType: "bytes32" }],
+  },
+  {
+    type: "error",
+    name: "OrderPortal__AdChainNotSupported",
+    inputs: [{ name: "adChainId", type: "uint256", internalType: "uint256" }],
+  },
+  {
+    type: "error",
+    name: "OrderPortal__AdManagerMismatch",
+    inputs: [{ name: "expected", type: "bytes32", internalType: "bytes32" }],
+  },
+  { type: "error", name: "OrderPortal__AdTokenMismatch", inputs: [] },
+  {
+    type: "error",
+    name: "OrderPortal__BridgerMustBeSender",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "OrderPortal__InsufficientLiquidity",
+    inputs: [],
+  },
+  { type: "error", name: "OrderPortal__InvalidProof", inputs: [] },
+  { type: "error", name: "OrderPortal__InvalidSigner", inputs: [] },
+  {
+    type: "error",
+    name: "OrderPortal__MerkleManagerAppendFailed",
+    inputs: [],
+  },
+  { type: "error", name: "OrderPortal__MissingRoute", inputs: [] },
+  {
+    type: "error",
+    name: "OrderPortal__NullifierUsed",
+    inputs: [
       {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: "nullifierHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
   {
-    "type": "function",
-    "name": "removeTokenRoute",
-    "inputs": [
-      {
-        "name": "orderToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+    type: "error",
+    name: "OrderPortal__OrderExists",
+    inputs: [{ name: "orderHash", type: "bytes32", internalType: "bytes32" }],
+  },
+  {
+    type: "error",
+    name: "OrderPortal__OrderNotOpen",
+    inputs: [{ name: "orderHash", type: "bytes32", internalType: "bytes32" }],
+  },
+  {
+    type: "error",
+    name: "OrderPortal__RequestHashedProcessed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "OrderPortal__RoutesZeroAddress",
+    inputs: [
+      { name: "orderToken", type: "address", internalType: "address" },
+      { name: "adToken", type: "bytes32", internalType: "bytes32" },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
+  { type: "error", name: "OrderPortal__TokenAlreadyUsed", inputs: [] },
+  { type: "error", name: "OrderPortal__ZeroAddress", inputs: [] },
+  { type: "error", name: "OrderPortal__ZeroAmount", inputs: [] },
+  { type: "error", name: "ReentrancyGuardReentrantCall", inputs: [] },
+  { type: "error", name: "RequestAuth__Expired", inputs: [] },
+  { type: "error", name: "RequestAuth__InvalidMessage", inputs: [] },
+  { type: "error", name: "RequestAuth__ZeroSigner", inputs: [] },
   {
-    "type": "function",
-    "name": "renounceRole",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "callerConfirmation",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [{ name: "token", type: "address", internalType: "address" }],
   },
-  {
-    "type": "function",
-    "name": "requestHashes",
-    "inputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "requestTokens",
-    "inputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "revokeRole",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setChain",
-    "inputs": [
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adManager",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "supported",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setManager",
-    "inputs": [
-      {
-        "name": "_manager",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "_status",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setTokenRoute",
-    "inputs": [
-      {
-        "name": "orderToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "adToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "supportsInterface",
-    "inputs": [
-      {
-        "name": "interfaceId",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "tokenRoute",
-    "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "unlock",
-    "inputs": [
-      {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "params",
-        "type": "tuple",
-        "internalType": "struct OrderPortal.OrderParams",
-        "components": [
-          {
-            "name": "orderChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adChainToken",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "bridger",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "orderRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adChainId",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "adManager",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adId",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "adCreator",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "adRecipient",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "salt",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "orderDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "adDecimals",
-            "type": "uint8",
-            "internalType": "uint8"
-          }
-        ]
-      },
-      {
-        "name": "nullifierHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "targetRoot",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "proof",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "unlockOrderRequestHash",
-    "inputs": [
-      {
-        "name": "adId",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "_targetRoot",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "authToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "timeToExpire",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "message",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "wNativeToken",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IwNativeToken"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "event",
-    "name": "ChainSet",
-    "inputs": [
-      {
-        "name": "chainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "adManager",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "supported",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OrderCreated",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "bridger",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "orderChainToken",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "adChainToken",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "adManager",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "adId",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      },
-      {
-        "name": "adCreator",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "adRecipient",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OrderUnlocked",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "recipient",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "nullifierHash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RoleAdminChanged",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "previousAdminRole",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "newAdminRole",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RoleGranted",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RoleRevoked",
-    "inputs": [
-      {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TokenRouteRemoved",
-    "inputs": [
-      {
-        "name": "orderChainToken",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TokenRouteSet",
-    "inputs": [
-      {
-        "name": "orderChainToken",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "adChainToken",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "UpdateManager",
-    "inputs": [
-      {
-        "name": "manager",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "status",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "error",
-    "name": "AccessControlBadConfirmation",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "AccessControlUnauthorizedAccount",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "neededRole",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AddressCast__NotEvmAddress",
-    "inputs": [
-      {
-        "name": "value",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "DecimalScaling__DecimalsMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "uint8",
-        "internalType": "uint8"
-      },
-      {
-        "name": "provided",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "DecimalScaling__DecimalsOutOfRange",
-    "inputs": [
-      {
-        "name": "value",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignature",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureS",
-    "inputs": [
-      {
-        "name": "s",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__AdChainNotSupported",
-    "inputs": [
-      {
-        "name": "adChainId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__AdManagerMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__AdTokenMismatch",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__BridgerMustBeSender",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__InsufficientLiquidity",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__InvalidProof",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__InvalidSigner",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__MerkleManagerAppendFailed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__MissingRoute",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__NullifierUsed",
-    "inputs": [
-      {
-        "name": "nullifierHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__OrderExists",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__OrderNotOpen",
-    "inputs": [
-      {
-        "name": "orderHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__RequestHashedProcessed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__RoutesZeroAddress",
-    "inputs": [
-      {
-        "name": "orderToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "adToken",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__TokenAlreadyUsed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__ZeroAddress",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OrderPortal__ZeroAmount",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ReentrancyGuardReentrantCall",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RequestAuth__Expired",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RequestAuth__InvalidMessage",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RequestAuth__ZeroSigner",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SafeERC20FailedOperation",
-    "inputs": [
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  }
-]
- as const;
+];

--- a/contracts/evm/src/AdManager.sol
+++ b/contracts/evm/src/AdManager.sol
@@ -775,6 +775,9 @@ contract AdManager is AccessControl, ReentrancyGuardTransient {
         if (params.bridger == bytes32(0)) revert AdManager__BridgerZero();
         if (params.orderRecipient == bytes32(0)) revert AdManager__RecipientZero();
 
+        // validate recipient address
+        params.orderRecipient.assertEvmAddress();
+
         // Cap both signed decimals to keep the scale factor well inside uint256 headroom.
         DecimalScaling.assertInRange(params.orderDecimals);
         DecimalScaling.assertInRange(params.adDecimals);

--- a/contracts/evm/src/OrderPortal.sol
+++ b/contracts/evm/src/OrderPortal.sol
@@ -487,8 +487,12 @@ contract OrderPortal is AccessControl, ReentrancyGuardTransient {
         if (params.bridger != msg.sender.toBytes32()) revert OrderPortal__BridgerMustBeSender();
         if (params.adRecipient == bytes32(0)) revert OrderPortal__ZeroAddress();
 
+        // validate recipient address
+        params.adRecipient.assertEvmAddress();
+
         // Cap both signed decimals; adDecimals is checked here (not just at scale time on
         // the ad chain) so invalid routes fail fast at create-time too.
+
         DecimalScaling.assertInRange(params.orderDecimals);
         DecimalScaling.assertInRange(params.adDecimals);
 

--- a/contracts/evm/src/libraries/AddressCast.sol
+++ b/contracts/evm/src/libraries/AddressCast.sol
@@ -27,8 +27,18 @@ library AddressCast {
      * @dev Reverts with `AddressCast__NotEvmAddress` if the top 12 bytes are set.
      */
     function toAddressChecked(bytes32 value) internal pure returns (address) {
-        if (uint256(value) >> 160 != 0) revert AddressCast__NotEvmAddress(value);
+        assertEvmAddress(value);
         return address(uint160(uint256(value)));
+    }
+
+    /**
+     * @notice Assert `value` is a valid EVM address (top 12 bytes are zero).
+     * @dev Same check as `toAddressChecked` but without the narrowing cast.
+     *      Use at validation sites where the address itself isn't needed yet,
+     *      so callers don't have to discard an unused return value.
+     */
+    function assertEvmAddress(bytes32 value) internal pure {
+        if (uint256(value) >> 160 != 0) revert AddressCast__NotEvmAddress(value);
     }
 
     /// @notice Whether `token` is the native-token sentinel.

--- a/contracts/evm/test/Admanager.t.sol
+++ b/contracts/evm/test/Admanager.t.sol
@@ -10,6 +10,7 @@ import {IMerkleManager} from "src/MerkleManager.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {IwNativeToken, wNativeToken} from "src/wNativeToken.sol";
+import {AddressCast} from "src/libraries/AddressCast.sol";
 
 contract MockAdManager is AdManager {
     constructor(address admin, IVerifier v, IMerkleManager m, IwNativeToken t) AdManager(admin, v, m, t) {}
@@ -756,6 +757,29 @@ contract AdManagerTest is Test {
 
         vm.prank(maker);
         vm.expectRevert(AdManager.AdManager__RecipientZero.selector);
+        adManager.lockForOrder(signature, authToken, timeToLive, p);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // lockForOrder: rejects orderRecipient with dirty upper 12 bytes
+    // ─────────────────────────────────────────────────────────────
+    function test_lock_rejects_orderRecipient_dirtyUpperBytes() public {
+        test_fundAd_makerOnly();
+        string memory adId = lastAdId;
+        AdManager.OrderParams memory p = _defaultParams(adId);
+
+        // Keep the low-20 the same as a valid recipient but set a non-zero
+        // byte above the EVM-address range. validateOrder must reject via
+        // assertEvmAddress so the bad bytes32 never sits in a signed order.
+        bytes32 dirty = _b32(recipient);
+        dirty |= bytes32(uint256(1) << 160);
+        p.orderRecipient = dirty;
+
+        bytes32 orderHash = adManager.hashOrderPublic(p);
+        (authToken, timeToLive, signature) = generateLockForOrderRequestHash(adId, orderHash);
+
+        vm.prank(maker);
+        vm.expectRevert(abi.encodeWithSelector(AddressCast.AddressCast__NotEvmAddress.selector, dirty));
         adManager.lockForOrder(signature, authToken, timeToLive, p);
     }
 

--- a/contracts/evm/test/OrderPortal.t.sol
+++ b/contracts/evm/test/OrderPortal.t.sol
@@ -10,6 +10,7 @@ import {IMerkleManager} from "src/MerkleManager.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {IwNativeToken, wNativeToken} from "src/wNativeToken.sol";
+import {AddressCast} from "src/libraries/AddressCast.sol";
 
 // Expose internal hash for assertions
 contract MockOrderPortal is OrderPortal {
@@ -354,6 +355,28 @@ contract OrderPortalTest is Test {
 
         vm.prank(bridger);
         vm.expectRevert(OrderPortal.OrderPortal__AdTokenMismatch.selector);
+        portal.createOrder(signature, authToken, timeToLive, p);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+      createOrder: rejects adRecipient with dirty upper 12 bytes
+    //////////////////////////////////////////////////////////////*/
+    function test_createOrder_rejects_adRecipient_dirtyUpperBytes() public {
+        test_setTokenRoute_setsAndEmits_whenSupported();
+        OrderPortal.OrderParams memory p = _defaultParams();
+
+        // Keep the low-20 the same as a valid recipient but set a non-zero
+        // byte above the EVM-address range. validateOrder must reject via
+        // assertEvmAddress so a bad bytes32 never sits in a signed order.
+        bytes32 dirty = _b32(adRecipient);
+        dirty |= bytes32(uint256(1) << 160);
+        p.adRecipient = dirty;
+
+        bytes32 orderHash = portal.hashOrderPublic(p);
+        (authToken, timeToLive, signature) = generateCreateOrderRequestParams(p.adId, orderHash);
+
+        vm.prank(bridger);
+        vm.expectRevert(abi.encodeWithSelector(AddressCast.AddressCast__NotEvmAddress.selector, dirty));
         portal.createOrder(signature, authToken, timeToLive, p);
     }
 

--- a/contracts/stellar/contracts/ad-manager/src/errors.rs
+++ b/contracts/stellar/contracts/ad-manager/src/errors.rs
@@ -100,6 +100,12 @@ pub enum AdManagerError {
     OrderDecimalsMismatch = 37,
     /// Signed adDecimals does not match on-chain token decimals
     AdDecimalsMismatch = 38,
+
+    // Address decode errors (40-41)
+    /// Recipient bytes do not decode to a valid Stellar account address
+    InvalidAccountAddress = 40,
+    /// Strkey produced by account-address validation was not valid ASCII
+    AccountValidationInvalidStrkey = 41,
 }
 
 impl proofbridge_core::errors::ProofBridgeError for AdManagerError {
@@ -138,5 +144,11 @@ impl proofbridge_core::errors::ProofBridgeError for AdManagerError {
     }
     fn ad_decimals_mismatch() -> Self {
         Self::AdDecimalsMismatch
+    }
+    fn invalid_account_address() -> Self {
+        Self::InvalidAccountAddress
+    }
+    fn account_validation_invalid_strkey() -> Self {
+        Self::AccountValidationInvalidStrkey
     }
 }

--- a/contracts/stellar/contracts/ad-manager/src/errors.rs
+++ b/contracts/stellar/contracts/ad-manager/src/errors.rs
@@ -104,8 +104,6 @@ pub enum AdManagerError {
     // Address decode errors (40-41)
     /// Recipient bytes do not decode to a valid Stellar account address
     InvalidAccountAddress = 40,
-    /// Strkey produced by account-address validation was not valid ASCII
-    AccountValidationInvalidStrkey = 41,
 }
 
 impl proofbridge_core::errors::ProofBridgeError for AdManagerError {
@@ -147,8 +145,5 @@ impl proofbridge_core::errors::ProofBridgeError for AdManagerError {
     }
     fn invalid_account_address() -> Self {
         Self::InvalidAccountAddress
-    }
-    fn account_validation_invalid_strkey() -> Self {
-        Self::AccountValidationInvalidStrkey
     }
 }

--- a/contracts/stellar/contracts/ad-manager/src/lib.rs
+++ b/contracts/stellar/contracts/ad-manager/src/lib.rs
@@ -216,13 +216,6 @@ impl AdManagerContract {
     // =========================================================================
 
     /// Create a new liquidity ad.
-    ///
-    /// `creator` is the ad creator's Stellar account. The ed25519 `signature`
-    /// is a manager's pre-authorization, not the creator's — mirroring the EVM
-    /// contract where `msg.sender` is the creator and `signer` from
-    /// `preAuthValidations` is merely a manager-role check. `creator.require_auth()`
-    /// is called at the root so the SAC `transfer(creator → contract)` sub-invocation
-    /// has proper authorization on live networks.
     pub fn create_ad(
         env: Env,
         signature: BytesN<64>,
@@ -316,9 +309,6 @@ impl AdManagerContract {
     }
 
     /// Fund an existing ad with additional liquidity.
-    ///
-    /// The ad's maker must authorize the call. `signer` from `verify_request`
-    /// is only used to confirm a registered manager pre-authorized the action.
     pub fn fund_ad(
         env: Env,
         signature: BytesN<64>,
@@ -633,8 +623,9 @@ impl AdManagerContract {
 
         // The order recipient on this (ad) chain authorizes the unlock —
         // mirrors the OrderPortal side where the ad recipient authorizes.
-        let order_recipient_addr =
-            proofbridge_core::token::bytes32_to_account_address(&env, &params.order_recipient);
+        let order_recipient_addr = proofbridge_core::token::bytes32_to_account_address::<
+            AdManagerError,
+        >(&env, &params.order_recipient)?;
         order_recipient_addr.require_auth();
 
         Self::assert_ad_decimals(&env, &params, &config.w_native_token)?;

--- a/contracts/stellar/contracts/ad-manager/src/test.rs
+++ b/contracts/stellar/contracts/ad-manager/src/test.rs
@@ -507,6 +507,24 @@ mod validation_tests {
     }
 
     #[test]
+    fn test_bytes32_to_account_address_rejects_zero() {
+        let env = Env::default();
+        let zero = zero_bytes32(&env);
+        let result: Result<Address, AdManagerError> =
+            proofbridge_core::token::bytes32_to_account_address(&env, &zero);
+        assert_eq!(result, Err(AdManagerError::InvalidAccountAddress));
+    }
+
+    #[test]
+    fn test_bytes32_to_account_address_decodes_non_zero() {
+        let env = Env::default();
+        let bytes = make_bytes32(&env, 0xAB);
+        let result: Result<Address, AdManagerError> =
+            proofbridge_core::token::bytes32_to_account_address(&env, &bytes);
+        assert!(result.is_ok(), "any non-zero 32-byte pubkey must decode");
+    }
+
+    #[test]
     fn test_validate_order_recipient_zero() {
         let env = setup_validation_env();
         env.as_contract(&env.register(AdManagerContract, ()), || {

--- a/contracts/stellar/contracts/ad-manager/src/validation.rs
+++ b/contracts/stellar/contracts/ad-manager/src/validation.rs
@@ -48,12 +48,12 @@ pub fn validate_order(env: &Env, ad: &Ad, params: &OrderParams) -> Result<(), Ad
         return Err(AdManagerError::BridgerZero);
     }
 
-    // order_recipient is paid out on this (ad) chain = Stellar
+    // Validate order_recipient (paid out on this ad chain = Stellar): must be
+    // non-zero and decode to a Stellar account address. Soroban contract
+    // (`C...`) addresses are not supported here.
     if auth::is_zero_bytes32(&params.order_recipient) {
         return Err(AdManagerError::RecipientZero);
     }
-
-    // validate recipient
     let _ = token::bytes32_to_account_address::<AdManagerError>(env, &params.order_recipient)?;
 
     // Check source chain is supported

--- a/contracts/stellar/contracts/ad-manager/src/validation.rs
+++ b/contracts/stellar/contracts/ad-manager/src/validation.rs
@@ -7,6 +7,7 @@ use soroban_sdk::Env;
 
 use proofbridge_core::decimal_scaling;
 use proofbridge_core::errors::map_decimal_scaling_error;
+use proofbridge_core::token;
 
 use crate::auth;
 use crate::errors::AdManagerError;
@@ -37,9 +38,6 @@ pub fn validate_order(env: &Env, ad: &Ad, params: &OrderParams) -> Result<(), Ad
     }
 
     // Decimal range checks (both sides must be within supported bounds).
-    // On-chain decimals *match* is checked separately in the contract entrypoint
-    // (requires a live SAC / wrapped-native contract, not available in pure
-    // validation unit tests).
     decimal_scaling::assert_in_range(params.order_decimals)
         .map_err(map_decimal_scaling_error::<AdManagerError>)?;
     decimal_scaling::assert_in_range(params.ad_decimals)
@@ -50,10 +48,13 @@ pub fn validate_order(env: &Env, ad: &Ad, params: &OrderParams) -> Result<(), Ad
         return Err(AdManagerError::BridgerZero);
     }
 
-    // Check recipient not zero
+    // order_recipient is paid out on this (ad) chain = Stellar
     if auth::is_zero_bytes32(&params.order_recipient) {
         return Err(AdManagerError::RecipientZero);
     }
+
+    // validate recipient
+    let _ = token::bytes32_to_account_address::<AdManagerError>(env, &params.order_recipient)?;
 
     // Check source chain is supported
     let chain_info =

--- a/contracts/stellar/contracts/order-portal/src/errors.rs
+++ b/contracts/stellar/contracts/order-portal/src/errors.rs
@@ -94,6 +94,14 @@ pub enum OrderPortalError {
     OrderDecimalsMismatch = 63,
     /// Signed adDecimals does not match on-chain token decimals
     AdDecimalsMismatch = 64,
+
+    // ==========================================================================
+    // Address Decode Errors (70-80)
+    // ==========================================================================
+    /// Recipient bytes do not decode to a valid Stellar account address
+    InvalidAccountAddress = 70,
+    /// Strkey produced by account-address validation was not valid ASCII
+    AccountValidationInvalidStrkey = 71,
 }
 
 impl proofbridge_core::errors::ProofBridgeError for OrderPortalError {
@@ -132,5 +140,11 @@ impl proofbridge_core::errors::ProofBridgeError for OrderPortalError {
     }
     fn ad_decimals_mismatch() -> Self {
         Self::AdDecimalsMismatch
+    }
+    fn invalid_account_address() -> Self {
+        Self::InvalidAccountAddress
+    }
+    fn account_validation_invalid_strkey() -> Self {
+        Self::AccountValidationInvalidStrkey
     }
 }

--- a/contracts/stellar/contracts/order-portal/src/errors.rs
+++ b/contracts/stellar/contracts/order-portal/src/errors.rs
@@ -100,8 +100,6 @@ pub enum OrderPortalError {
     // ==========================================================================
     /// Recipient bytes do not decode to a valid Stellar account address
     InvalidAccountAddress = 70,
-    /// Strkey produced by account-address validation was not valid ASCII
-    AccountValidationInvalidStrkey = 71,
 }
 
 impl proofbridge_core::errors::ProofBridgeError for OrderPortalError {
@@ -143,8 +141,5 @@ impl proofbridge_core::errors::ProofBridgeError for OrderPortalError {
     }
     fn invalid_account_address() -> Self {
         Self::InvalidAccountAddress
-    }
-    fn account_validation_invalid_strkey() -> Self {
-        Self::AccountValidationInvalidStrkey
     }
 }

--- a/contracts/stellar/contracts/order-portal/src/lib.rs
+++ b/contracts/stellar/contracts/order-portal/src/lib.rs
@@ -264,7 +264,8 @@ impl OrderPortalContract {
         )?;
 
         // Transfer tokens from bridger to contract
-        let bridger_addr = token::bytes32_to_account_address(&env, &params.bridger);
+        let bridger_addr =
+            token::bytes32_to_account_address::<OrderPortalError>(&env, &params.bridger)?;
 
         // Root-level auth for the SAC transfer sub-invocation that will call
         // `from.require_auth()` internally. When the bridger is also the tx
@@ -328,8 +329,9 @@ impl OrderPortalContract {
 
         // The ad recipient on this (order) chain authorizes the unlock —
         // mirrors AdManager's unlock where the order recipient authorizes.
-        let ad_recipient_addr =
-            proofbridge_core::token::bytes32_to_account_address(&env, &params.ad_recipient);
+        let ad_recipient_addr = proofbridge_core::token::bytes32_to_account_address::<
+            OrderPortalError,
+        >(&env, &params.ad_recipient)?;
         ad_recipient_addr.require_auth();
 
         Self::assert_order_decimals(&env, &params, &config.w_native_token)?;

--- a/contracts/stellar/contracts/order-portal/src/test.rs
+++ b/contracts/stellar/contracts/order-portal/src/test.rs
@@ -191,6 +191,26 @@ mod validation_tests {
     }
 
     #[test]
+    fn test_bytes32_to_account_address_rejects_zero() {
+        let env = Env::default();
+        let zero = zero_bytes32(&env);
+        // Direct call into the refactored helper — zero bytes must surface as
+        // the typed contract-specific error, not a panic.
+        let result: Result<Address, OrderPortalError> =
+            proofbridge_core::token::bytes32_to_account_address(&env, &zero);
+        assert_eq!(result, Err(OrderPortalError::InvalidAccountAddress));
+    }
+
+    #[test]
+    fn test_bytes32_to_account_address_decodes_non_zero() {
+        let env = Env::default();
+        let bytes = make_bytes32(&env, 0xAB);
+        let result: Result<Address, OrderPortalError> =
+            proofbridge_core::token::bytes32_to_account_address(&env, &bytes);
+        assert!(result.is_ok(), "any non-zero 32-byte pubkey must decode");
+    }
+
+    #[test]
     fn test_validate_order_invalid_ad_recipient() {
         let env = Env::default();
         env.as_contract(&env.register(OrderPortalContract, ()), || {

--- a/contracts/stellar/contracts/order-portal/src/validation.rs
+++ b/contracts/stellar/contracts/order-portal/src/validation.rs
@@ -7,6 +7,7 @@ use soroban_sdk::Env;
 
 use proofbridge_core::decimal_scaling;
 use proofbridge_core::errors::map_decimal_scaling_error;
+use proofbridge_core::token;
 
 use crate::auth;
 use crate::errors::OrderPortalError;
@@ -27,15 +28,15 @@ pub fn validate_order(env: &Env, params: &OrderParams) -> Result<(), OrderPortal
         return Err(OrderPortalError::ZeroAmount);
     }
 
-    // Check ad_recipient not zero
+    // validate recipient
     if auth::is_zero_bytes32(&params.ad_recipient) {
         return Err(OrderPortalError::InvalidAdRecipient);
     }
 
+    // validate recipient
+    let _ = token::bytes32_to_account_address::<OrderPortalError>(env, &params.ad_recipient)?;
+
     // Decimal range checks (both sides must be within supported bounds).
-    // On-chain decimals *match* is checked separately in the contract entrypoint
-    // (requires a live SAC / wrapped-native contract, not available in pure
-    // validation unit tests).
     decimal_scaling::assert_in_range(params.order_decimals)
         .map_err(map_decimal_scaling_error::<OrderPortalError>)?;
     decimal_scaling::assert_in_range(params.ad_decimals)

--- a/contracts/stellar/contracts/order-portal/src/validation.rs
+++ b/contracts/stellar/contracts/order-portal/src/validation.rs
@@ -28,12 +28,11 @@ pub fn validate_order(env: &Env, params: &OrderParams) -> Result<(), OrderPortal
         return Err(OrderPortalError::ZeroAmount);
     }
 
-    // validate recipient
+    // Validate recipient: must be non-zero and decode to a Stellar account
+    // address. Soroban contract (`C...`) addresses are not supported here.
     if auth::is_zero_bytes32(&params.ad_recipient) {
         return Err(OrderPortalError::InvalidAdRecipient);
     }
-
-    // validate recipient
     let _ = token::bytes32_to_account_address::<OrderPortalError>(env, &params.ad_recipient)?;
 
     // Decimal range checks (both sides must be within supported bounds).

--- a/contracts/stellar/lib/proofbridge-core/src/errors.rs
+++ b/contracts/stellar/lib/proofbridge-core/src/errors.rs
@@ -19,6 +19,8 @@ pub trait ProofBridgeError: Copy {
     fn decimal_overflow() -> Self;
     fn order_decimals_mismatch() -> Self;
     fn ad_decimals_mismatch() -> Self;
+    fn invalid_account_address() -> Self;
+    fn account_validation_invalid_strkey() -> Self;
 }
 
 /// Convert a [`crate::decimal_scaling::DecimalScalingError`] into the

--- a/contracts/stellar/lib/proofbridge-core/src/errors.rs
+++ b/contracts/stellar/lib/proofbridge-core/src/errors.rs
@@ -20,7 +20,6 @@ pub trait ProofBridgeError: Copy {
     fn order_decimals_mismatch() -> Self;
     fn ad_decimals_mismatch() -> Self;
     fn invalid_account_address() -> Self;
-    fn account_validation_invalid_strkey() -> Self;
 }
 
 /// Convert a [`crate::decimal_scaling::DecimalScalingError`] into the

--- a/contracts/stellar/lib/proofbridge-core/src/token.rs
+++ b/contracts/stellar/lib/proofbridge-core/src/token.rs
@@ -45,10 +45,13 @@ pub fn bytes32_to_token_address(env: &Env, bytes: &BytesN<32>) -> Option<Address
     Some(Address::from_string(&soroban_str))
 }
 
-/// Convert BytesN<32> account address (Ed25519 public key) to Soroban Address.
+/// Re-encode a BytesN<32> Ed25519 pubkey as a Soroban `G...` account `Address`.
 ///
-/// Returns the contract-specific `invalid_account_address()` error when the
-/// input bytes cannot produce a usable Stellar account address.
+/// Rejects the all-zero 32-byte pubkey with `E::invalid_account_address()`.
+/// Any other 32-byte value is deterministically strkey-encoded and wrapped as
+/// an `Address`; this does NOT verify the key corresponds to a funded or
+/// existing Stellar account, and it only produces account (`G...`) addresses —
+/// Soroban contract (`C...`) addresses are not supported here.
 pub fn bytes32_to_account_address<E: ProofBridgeError>(
     env: &Env,
     bytes: &BytesN<32>,
@@ -59,13 +62,8 @@ pub fn bytes32_to_account_address<E: ProofBridgeError>(
         return Err(E::invalid_account_address());
     }
 
-    let pubkey = PublicKey(bytes.to_array());
-    let strkey = pubkey.to_string();
-
-    let strkey_str = core::str::from_utf8(strkey.as_bytes())
-        .map_err(|_| E::account_validation_invalid_strkey())?;
-
-    let soroban_str = SorobanString::from_str(env, strkey_str);
+    let strkey = PublicKey(bytes.to_array()).to_string();
+    let soroban_str = SorobanString::from_str(env, strkey.as_str());
     Ok(Address::from_string(&soroban_str))
 }
 

--- a/contracts/stellar/lib/proofbridge-core/src/token.rs
+++ b/contracts/stellar/lib/proofbridge-core/src/token.rs
@@ -45,16 +45,28 @@ pub fn bytes32_to_token_address(env: &Env, bytes: &BytesN<32>) -> Option<Address
     Some(Address::from_string(&soroban_str))
 }
 
-/// Convert BytesN<32> account address (Ed25519 public key) to Soroban Address
-pub fn bytes32_to_account_address(env: &Env, bytes: &BytesN<32>) -> Address {
+/// Convert BytesN<32> account address (Ed25519 public key) to Soroban Address.
+///
+/// Returns the contract-specific `invalid_account_address()` error when the
+/// input bytes cannot produce a usable Stellar account address.
+pub fn bytes32_to_account_address<E: ProofBridgeError>(
+    env: &Env,
+    bytes: &BytesN<32>,
+) -> Result<Address, E> {
     use stellar_strkey::ed25519::PublicKey;
+
+    if bytes.to_array().iter().all(|&b| b == 0) {
+        return Err(E::invalid_account_address());
+    }
 
     let pubkey = PublicKey(bytes.to_array());
     let strkey = pubkey.to_string();
 
-    let strkey_bytes = strkey.as_bytes();
-    let soroban_str = SorobanString::from_str(env, core::str::from_utf8(strkey_bytes).unwrap());
-    Address::from_string(&soroban_str)
+    let strkey_str = core::str::from_utf8(strkey.as_bytes())
+        .map_err(|_| E::account_validation_invalid_strkey())?;
+
+    let soroban_str = SorobanString::from_str(env, strkey_str);
+    Ok(Address::from_string(&soroban_str))
 }
 
 // =============================================================================
@@ -121,10 +133,6 @@ pub fn transfer_to_user_bytes32<E: ProofBridgeError>(
 }
 
 /// Query the `decimals()` view of a token referenced by BytesN<32>.
-///
-/// For the native token marker, reads from the wrapped-native token contract.
-/// Returns [`ProofBridgeError::token_zero_address`] if the bytes32 does not
-/// resolve to a contract address.
 pub fn token_decimals_bytes32<E: ProofBridgeError>(
     env: &Env,
     token_bytes: &BytesN<32>,
@@ -150,7 +158,7 @@ pub fn transfer_to_recipient_bytes32<E: ProofBridgeError>(
     amount: u128,
 ) -> Result<(), E> {
     let contract_addr = env.current_contract_address();
-    let recipient = bytes32_to_account_address(env, recipient_bytes);
+    let recipient = bytes32_to_account_address::<E>(env, recipient_bytes)?;
     transfer_tokens(
         env,
         token_bytes,


### PR DESCRIPTION
Reject bytes32 recipients with dirty upper 12 bytes on EVM via a new AddressCast.assertEvmAddress helper, and reject non-decodable 32-byte pubkeys on Stellar by routing through bytes32_to_account_address with typed errors (InvalidAccountAddress). Wired into validateOrder on both OrderPortal and AdManager so both create/lock and unlock paths enforce the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced address validation for cross-chain transactions to ensure recipient addresses are properly formatted.

* **Bug Fixes**
  * Added validation checks to reject invalid EVM and Stellar addresses during order operations, preventing failed cross-chain transfers.

* **Chores**
  * Updated contract interfaces and error types to support improved address validation.
  * Improved error handling for address format failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->